### PR TITLE
BRS-144 fixing search by date on pass filters

### DIFF
--- a/lambda/readPass/index.js
+++ b/lambda/readPass/index.js
@@ -41,7 +41,7 @@ exports.handler = async (event, context) => {
       // Filter Date
       if (event.queryStringParameters.date) {
         const theDate = new Date(event.queryStringParameters.date);
-        var month = ('0' + theDate.getMonth()).slice(-2);
+        var month = ('0' + theDate.getMonth() + 1).slice(-2);
         var day = ('0' + theDate.getUTCDate()).slice(-2);
         var year = theDate.getUTCFullYear();
         const dateselector = year + '-' + month + '-' + day;


### PR DESCRIPTION
### Jira Ticket:
BRS-144

### Jira Ticket URL:
https://bcmines.atlassian.net/browse/BRS-144

### Description:
This ticket fixes a bug where the search filtering within facility passes would not return results if filtered by date. The issue was due to lambda function incorrectly parsing the date object. The JavaScript function `getMonth()` is zero-indexed and therefore the API was querying for dates 1 month prior to the one requested in the filtration widget.
