### PR TITLE
BRS-165: only allow one pass cancellation

### DIFF
--- a/lambda/deletePass/index.js
+++ b/lambda/deletePass/index.js
@@ -32,7 +32,9 @@ exports.handler = async (event, context) => {
         ExpressionAttributeValues: {
           ':cancelled': { S: 'cancelled' }
         },
-        ConditionExpression: 'attribute_exists(pk) AND attribute_exists(sk)',
+        // If the pass is already cancelled, error so that we don't decrement the available
+        // count multiple times.
+        ConditionExpression: 'attribute_exists(pk) AND attribute_exists(sk) AND (NOT passStatus = :cancelled)',
         UpdateExpression: 'SET passStatus = :cancelled',
         ReturnValues: 'ALL_NEW',
         TableName: process.env.TABLE_NAME


### PR DESCRIPTION
### Jira Ticket:
BRS-165

### Jira Ticket URL:
https://bcmines.atlassian.net/browse/BRS-165

### Description:
I think I finally found the bug 😅 - hitting reload on the cancel page will lower the reservation count again.

Adds a check when cancelling a pass that it's not already in a cancelled state. This is needed to prevent multiple cancellations of the same pass from decrementing the reservation count multiple times.
