### PR TITLE
NOBUG: Fix captcha secret name

### DIFF
--- a/terraform/src/captcha.tf
+++ b/terraform/src/captcha.tf
@@ -1,5 +1,5 @@
 data "aws_secretsmanager_secret_version" "private_key" {
-  secret_id = "${var.target_env}/parks-reso-admin/captcha-private-key"
+  secret_id = "${var.target_env}/parks-reso-api/captcha-private-key"
 }
 
 locals {


### PR DESCRIPTION
### Description:

Fix the wrong name used by the captcha private key secret.  New secret name has already been created in AWS
