### PR TITLE
BRS-161: update pass activation logic

### DIFF
--- a/__tests__/checkActivation.test.js
+++ b/__tests__/checkActivation.test.js
@@ -1,0 +1,324 @@
+const MockDate = require('mockdate');
+const { formatISO } = require('date-fns');
+const AWS = require('aws-sdk');
+const { DocumentClient } = require('aws-sdk/clients/dynamodb');
+
+const checkActivation = require('../lambda/checkActivation/index');
+
+const REGION = process.env.AWS_REGION || 'local-env';
+const ENDPOINT = 'http://localhost:8000';
+const TABLE_NAME = process.env.TABLE_NAME || 'parksreso';
+
+let dynamoDb;
+let docClient;
+
+async function setupDb() {
+  dynamoDb = new AWS.DynamoDB({
+    region: REGION,
+    endpoint: ENDPOINT
+  });
+  docClient = new DocumentClient({
+    region: REGION,
+    endpoint: ENDPOINT,
+    convertEmptyValues: true
+  });
+  try {
+    await dynamoDb
+      .createTable({
+        TableName: TABLE_NAME,
+        KeySchema: [
+          {
+            AttributeName: 'pk',
+            KeyType: 'HASH'
+          },
+          {
+            AttributeName: 'sk',
+            KeyType: 'RANGE'
+          }
+        ],
+        AttributeDefinitions: [
+          {
+            AttributeName: 'pk',
+            AttributeType: 'S'
+          },
+          {
+            AttributeName: 'sk',
+            AttributeType: 'S'
+          }
+        ],
+        ProvisionedThroughput: {
+          ReadCapacityUnits: 1,
+          WriteCapacityUnits: 1
+        }
+      })
+      .promise();
+  } catch (err) {
+    console.log(err);
+  }
+  await docClient
+    .put({
+      TableName: TABLE_NAME,
+      Item: {
+        pk: 'config',
+        sk: 'config',
+        BOOKING_OPENING_HOUR: 7
+      }
+    })
+    .promise();
+  await docClient
+    .put({
+      TableName: TABLE_NAME,
+      Item: {
+        pk: 'park',
+        sk: 'Test Park',
+        name: 'Test Park',
+        description: '',
+        bcParksLink: '',
+        status: 'open',
+        visible: true
+      }
+    })
+    .promise();
+  await docClient
+    .put({
+      TableName: TABLE_NAME,
+      Item: {
+        pk: 'facility::Test Park',
+        sk: 'Parking Lot A',
+        name: 'Parking Lot A',
+        description: '',
+        bcParksLink: '',
+        status: 'open',
+        visible: true,
+        type: 'parking',
+        reservations: {},
+        bookingOpeningHour: null,
+        bookingDaysAhead: null
+      }
+    })
+    .promise();
+  await docClient
+    .put({
+      TableName: TABLE_NAME,
+      Item: {
+        pk: 'facility::Test Park',
+        sk: 'Parking Lot B',
+        name: 'Parking Lot B',
+        description: '',
+        bcParksLink: '',
+        status: 'open',
+        visible: true,
+        type: 'parking',
+        reservations: {},
+        bookingOpeningHour: 10,
+        bookingDaysAhead: null
+      }
+    })
+    .promise();
+}
+
+describe('checkActivationHandler', () => {
+  beforeAll(() => {
+    return setupDb();
+  });
+
+  test('should not update old passes', async () => {
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 5);
+
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: '123456700',
+          facilityName: 'Parking Lot A',
+          type: 'DAY',
+          registrationNumber: '123456700',
+          passStatus: 'reserved',
+          date: formatISO(oldDate, { representation: 'date' })
+        }
+      })
+      .promise();
+
+    MockDate.set(new Date('2021-12-08T11:01:58.135Z'));
+    await checkActivation.handler(null, {});
+    MockDate.reset();
+
+    const result = await docClient
+      .get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: 'pass::Test Park',
+          sk: '123456700'
+        }
+      })
+      .promise();
+    expect(result.Item.passStatus).toBe('reserved');
+  });
+
+  test.each([['AM', '123456702'], ['DAY', '123456703']])('should set %s passes with default opening hour to active', async (passType, sk) => {
+    const passDate = new Date('2021-12-08T19:01:58.135Z');
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: sk,
+          facilityName: 'Parking Lot A',
+          type: passType,
+          registrationNumber: sk,
+          passStatus: 'reserved',
+          date: formatISO(passDate, { representation: 'date' })
+        }
+      })
+      .promise();
+
+    MockDate.set(new Date('2021-12-08T19:01:58.135Z'));
+    await checkActivation.handler(null, {});
+    MockDate.reset();
+
+    const result = await docClient
+      .get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: 'pass::Test Park',
+          sk: sk
+        }
+      })
+      .promise();
+    expect(result.Item.passStatus).toBe('active');
+  });
+
+  test.each([['AM', '123456704'], ['DAY', '123456705']])('should leave %s passes inactive before custom opening hour', async (passType, sk) => {
+    const passDate = new Date('2021-12-08T19:01:58.135Z');
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: sk,
+          facilityName: 'Parking Lot B',
+          type: passType,
+          registrationNumber: sk,
+          passStatus: 'reserved',
+          date: formatISO(passDate, { representation: 'date' })
+        }
+      })
+      .promise();
+
+    MockDate.set(new Date('2021-12-08T17:01:58.135Z'));
+    await checkActivation.handler(null, {});
+    MockDate.reset();
+
+    const result = await docClient
+      .get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: 'pass::Test Park',
+          sk: sk,
+        }
+      })
+      .promise();
+    expect(result.Item.passStatus).toBe('reserved');
+  });
+
+  test.each([['AM', '123456706'], ['DAY', '123456707']])('should set %s passes to active after custom opening hour', async (passType, sk) => {
+    const passDate = new Date('2021-12-08T19:01:58.135Z');
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: sk,
+          facilityName: 'Parking Lot B',
+          type: passType,
+          registrationNumber: sk,
+          passStatus: 'reserved',
+          date: formatISO(passDate, { representation: 'date' })
+        }
+      })
+      .promise();
+
+    MockDate.set(new Date('2021-12-08T18:00:00.00Z'));
+    await checkActivation.handler(null, {});
+    MockDate.reset();
+
+    const result = await docClient
+      .get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: 'pass::Test Park',
+          sk: sk,
+        }
+      })
+      .promise();
+    expect(result.Item.passStatus).toBe('active');
+  });
+
+  test('should leave PM passes before 12:00 inactive', async () => {
+    const passDate = new Date('2021-12-08T19:01:58.135Z');
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: '123456708',
+          facilityName: 'Parking Lot A',
+          type: 'PM',
+          registrationNumber: '123456708',
+          passStatus: 'reserved',
+          date: formatISO(passDate, { representation: 'date' })
+        }
+      })
+      .promise();
+
+    MockDate.set(new Date('2021-12-08T19:59:59.999Z'));
+    await checkActivation.handler(null, {});
+    MockDate.reset();
+
+    const result = await docClient
+      .get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: 'pass::Test Park',
+          sk: '123456708'
+        }
+      })
+      .promise();
+    expect(result.Item.passStatus).toBe('reserved');
+  });
+
+  test('should set PM passes after 12:00 to active', async () => {
+    const passDate = new Date('2021-12-08T19:01:58.135Z');
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: '123456709',
+          facilityName: 'Parking Lot A',
+          type: 'PM',
+          registrationNumber: '123456709',
+          passStatus: 'reserved',
+          date: formatISO(passDate, { representation: 'date' })
+        }
+      })
+      .promise();
+
+    MockDate.set(new Date('2021-12-08T22:01:58.135Z'));
+    await checkActivation.handler(null, {});
+    MockDate.reset();
+
+    const result = await docClient
+      .get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: 'pass::Test Park',
+          sk: '123456709'
+        }
+      })
+      .promise();
+    expect(result.Item.passStatus).toBe('active');
+  });
+});

--- a/__tests__/checkExpiry.test.js
+++ b/__tests__/checkExpiry.test.js
@@ -1,0 +1,264 @@
+const MockDate = require('mockdate');
+const { formatISO } = require('date-fns');
+const AWS = require('aws-sdk');
+const { DocumentClient } = require('aws-sdk/clients/dynamodb');
+
+const checkExpiry = require('../lambda/checkExpiry/index');
+
+const REGION = process.env.AWS_REGION || 'local-env';
+const ENDPOINT = 'http://localhost:8000';
+const TABLE_NAME = process.env.TABLE_NAME || 'parksreso';
+
+let dynamoDb;
+let docClient;
+
+async function setupDb() {
+  dynamoDb = new AWS.DynamoDB({
+    region: REGION,
+    endpoint: ENDPOINT
+  });
+  docClient = new DocumentClient({
+    region: REGION,
+    endpoint: ENDPOINT,
+    convertEmptyValues: true
+  });
+  try {
+    await dynamoDb
+      .createTable({
+        TableName: TABLE_NAME,
+        KeySchema: [
+          {
+            AttributeName: 'pk',
+            KeyType: 'HASH'
+          },
+          {
+            AttributeName: 'sk',
+            KeyType: 'RANGE'
+          }
+        ],
+        AttributeDefinitions: [
+          {
+            AttributeName: 'pk',
+            AttributeType: 'S'
+          },
+          {
+            AttributeName: 'sk',
+            AttributeType: 'S'
+          }
+        ],
+        ProvisionedThroughput: {
+          ReadCapacityUnits: 1,
+          WriteCapacityUnits: 1
+        }
+      })
+      .promise();
+  } catch (err) {
+    console.log(err);
+  }
+  await docClient
+    .put({
+      TableName: TABLE_NAME,
+      Item: {
+        pk: 'park',
+        sk: 'Test Park',
+        name: 'Test Park',
+        description: '',
+        bcParksLink: '',
+        status: 'open',
+        visible: true
+      }
+    })
+    .promise();
+  await docClient
+    .put({
+      TableName: TABLE_NAME,
+      Item: {
+        pk: 'facility::Test Park',
+        sk: 'Parking Lot A',
+        name: 'Parking Lot A',
+        description: '',
+        bcParksLink: '',
+        status: 'open',
+        visible: true,
+        type: 'parking',
+        reservations: {},
+        bookingOpeningHour: null,
+        bookingDaysAhead: null
+      }
+    })
+    .promise();
+}
+
+describe('checkExpiryHandler', () => {
+  beforeAll(() => {
+    return setupDb();
+  });
+
+  test('should not update old passes', async () => {
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 5);
+
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: '123456710',
+          facilityName: 'Parking Lot A',
+          type: 'DAY',
+          registrationNumber: '123456710',
+          passStatus: 'active',
+          date: formatISO(oldDate, { representation: 'date' })
+        }
+      })
+      .promise();
+
+    MockDate.set(new Date('2021-12-08T11:01:30.135Z'));
+    await checkExpiry.handler(null, {});
+    MockDate.reset();
+
+    const result = await docClient
+      .get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: 'pass::Test Park',
+          sk: '123456710'
+        }
+      })
+      .promise();
+    expect(result.Item.passStatus).toBe('active');
+  });
+
+  test.each([['PM', '123456711'], ['DAY', '123456712']])('should set %s passes from yesterday to expired', async (passType, sk) => {
+    const passDate = new Date('2021-12-07T11:07:58.135Z');
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: sk,
+          facilityName: 'Parking Lot A',
+          type: passType,
+          registrationNumber: sk,
+          passStatus: 'active',
+          date: formatISO(passDate, { representation: 'date' })
+        }
+      })
+      .promise();
+
+    MockDate.set(new Date('2021-12-08T08:01:58.135Z'));
+    await checkExpiry.handler(null, {});
+    MockDate.reset();
+
+    const result = await docClient
+      .get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: 'pass::Test Park',
+          sk: sk
+        }
+      })
+      .promise();
+    expect(result.Item.passStatus).toBe('expired');
+  });
+
+  test.each([['PM', '123456713'], ['DAY', '123456714']])('should not set %s passes from today to expired', async (passType, sk) => {
+    const passDate = new Date('2021-12-08T11:02:43.135Z');
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: sk,
+          facilityName: 'Parking Lot A',
+          type: passType,
+          registrationNumber: sk,
+          passStatus: 'active',
+          date: formatISO(passDate, { representation: 'date' })
+        }
+      })
+      .promise();
+
+    MockDate.set(new Date('2021-12-08T19:01:58.135Z'));
+    await checkExpiry.handler(null, {});
+    MockDate.reset();
+
+    const result = await docClient
+      .get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: 'pass::Test Park',
+          sk: sk
+        }
+      })
+      .promise();
+    expect(result.Item.passStatus).toBe('active');
+  });
+
+  test('should set AM passes to expired after 12:00', async () => {
+    const passDate = new Date('2021-12-08T11:01:02.135Z');
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: '123456715',
+          facilityName: 'Parking Lot A',
+          type: 'AM',
+          registrationNumber: '123456715',
+          passStatus: 'active',
+          date: formatISO(passDate, { representation: 'date' })
+        }
+      })
+      .promise();
+
+    MockDate.set(new Date('2021-12-08T20:00:00.001Z'));
+    await checkExpiry.handler(null, {});
+    MockDate.reset();
+
+    const result = await docClient
+      .get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: 'pass::Test Park',
+          sk: '123456715'
+        }
+      })
+      .promise();
+    expect(result.Item.passStatus).toBe('expired');
+  });
+
+  test('should set not AM passes to expired before 12:00', async () => {
+    const passDate = new Date('2021-12-08T11:01:58.135Z');
+    await docClient
+      .put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: '123456716',
+          facilityName: 'Parking Lot A',
+          type: 'AM',
+          registrationNumber: '123456716',
+          passStatus: 'active',
+          date: formatISO(passDate, { representation: 'date' })
+        }
+      })
+      .promise();
+
+    MockDate.set(new Date('2021-12-08T19:59:59.999Z'));
+    await checkExpiry.handler(null, {});
+    MockDate.reset();
+
+    const result = await docClient
+      .get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: 'pass::Test Park',
+          sk: '123456716'
+        }
+      })
+      .promise();
+    expect(result.Item.passStatus).toBe('active');
+  });
+
+});

--- a/lambda/checkExpiry/index.js
+++ b/lambda/checkExpiry/index.js
@@ -1,49 +1,72 @@
-const { runQuery, setStatus } = require('../dynamoUtil');
+const { formatISO, subDays, getHours } = require('date-fns');
+const { utcToZonedTime } = require('date-fns-tz');
+
+const { runQuery, setStatus, getParks } = require('../dynamoUtil');
 const { sendResponse } = require('../responseUtil');
 
+const TABLE_NAME = process.env.TABLE_NAME || 'parksreso';
+const TIMEZONE = 'America/Vancouver';
+const ACTIVE_STATUS = 'active';
+const EXPIRED_STATUS = 'expired';
+const PASS_TYPE_EXPIRY_HOURS = {
+  AM: 12,
+  PM: 0,
+  DAY: 0
+};
+
 exports.handler = async (event, context) => {
-  console.log('check expiry', event);
-
-  let queryObj = {
-    TableName: process.env.TABLE_NAME
-  };
-
-  // Look for today's expiries
-  let yd = new Date();
-  yd.setDate(yd.getDate() - 1);
-  const yesterdaysDate = yd.toISOString().split('T')[0];
-
+  console.log('Event', event, context);
   try {
-    queryObj.ExpressionAttributeValues = {};
-    queryObj.ExpressionAttributeValues[':pk'] = { S: 'park' };
-    queryObj.KeyConditionExpression = 'pk =:pk';
-    console.log("queryObj:", queryObj);
+    const utcNow = Date.now();
+    const localNow = utcToZonedTime(utcNow, TIMEZONE);
+    const localHour = getHours(localNow);
+    const yesterday = subDays(new Date(localNow), 1);
+    console.log(`UTC: ${utcNow}; local (${TIMEZONE}): ${localNow}; yesterday: ${yesterday}`);
 
-    const parkData = await runQuery(queryObj);
+    for (const passType in PASS_TYPE_EXPIRY_HOURS) {
+      const expiryHour = PASS_TYPE_EXPIRY_HOURS[passType];
+      if (localHour < expiryHour) {
+        console.log(`${passType} passes don't expire yet`);
+        continue;
+      }
 
-    for (let i = 0; i < parkData.length; i++) {
-      let passQuery = {
-        TableName: process.env.TABLE_NAME
-      };
-      passQuery.ExpressionAttributeNames = {
-        '#dateselector': 'date'
-      };
-      passQuery.ExpressionAttributeValues = {};
-      passQuery.ExpressionAttributeValues[':pk'] = { S: 'pass::' + parkData[i].sk };
-      passQuery.ExpressionAttributeValues[':yesterdaysDate'] = { S: yesterdaysDate };
-      passQuery.ExpressionAttributeValues[':activeStatus'] = { S: 'active' };
-      passQuery.KeyConditionExpression = 'pk =:pk';
-      passQuery.FilterExpression = 'begins_with(#dateselector, :yesterdaysDate) AND passStatus =:activeStatus';
-
-      console.log("passQuery:", passQuery);
-      const passData = await runQuery(passQuery);
-      console.log("passData:", passData);
-
-      await setStatus(passData, 'expired');
+      // If expiring at midnight, check yesterday's passes.
+      const expiryDate = expiryHour === 0 ? yesterday : localNow;
+      const parks = await getParks();
+      for (const park of parks) {
+        const passes = await getExpiredPasses(passType, expiryDate, park.name);
+        await setStatus(passes, EXPIRED_STATUS);
+      }
     }
+
     return sendResponse(200, {}, context);
   } catch (err) {
-    console.log(err);
-    return sendResponse(200, { msg: 'Activation Check Complete' }, context);
+    console.error(err);
+
+    return sendResponse(500, {}, context);
   }
+};
+
+async function getExpiredPasses(passType, passDate, parkName) {
+  const dateSelector = formatISO(passDate, { representation: 'date' });
+
+  console.log(`Loading ${passType} passes on ${dateSelector} for ${parkName}`);
+
+  const passesQuery = {
+    TableName: TABLE_NAME,
+    KeyConditionExpression: 'pk = :pk',
+    ExpressionAttributeNames: {
+      '#dateselector': 'date',
+      '#passType': 'type'
+    },
+    ExpressionAttributeValues: {
+      ':pk': { S: `pass::${parkName}` },
+      ':activeDate': { S: dateSelector },
+      ':activeStatus': { S: ACTIVE_STATUS },
+      ':passType': { S: passType }
+    },
+    FilterExpression: 'begins_with(#dateselector, :activeDate) AND #passType = :passType AND passStatus = :activeStatus'
+  };
+
+  return await runQuery(passesQuery);
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.44.0",
     "aws-sdk-mock": "^5.4.0",
+    "date-fns": "^2.27.0",
+    "date-fns-tz": "^1.1.6",
     "jest": "^27.4.0",
+    "mockdate": "^3.0.5",
     "serverless": "^2.61.0",
     "serverless-dynamodb-local": "^0.2.40",
     "serverless-offline": "^8.2.0",
@@ -21,7 +24,7 @@
   "scripts": {
     "start": "sls offline start",
     "build": "sls package --package ./artifacts",
-    "test": "jest --coverage"
+    "test": "IS_OFFLINE=1 jest --coverage"
   },
   "jest": {
     "verbose": true

--- a/terraform/src/activationJob.tf
+++ b/terraform/src/activationJob.tf
@@ -15,14 +15,14 @@ resource "aws_lambda_function" "check_activation" {
   role = aws_iam_role.readRole.arn
 }
 
-resource "aws_cloudwatch_event_rule" "every_morning_at_7am" {
-  name                = "every-morning-at-7am"
-  description         = "Fires every morning at 2pm UTC (7am Pacific)"
-  schedule_expression = "cron(0 14 * * ? *)"
+resource "aws_cloudwatch_event_rule" "activation_every_hour" {
+  name                = "activation-every-hour"
+  description         = "Fires hourly"
+  schedule_expression = "cron(0 * * * ? *)"
 }
 
-resource "aws_cloudwatch_event_target" "check_activation_every_morning_at_7am" {
-  rule      = aws_cloudwatch_event_rule.every_morning_at_7am.name
+resource "aws_cloudwatch_event_target" "check_activation_every_hour" {
+  rule      = aws_cloudwatch_event_rule.activation_every_hour.name
   target_id = "check_activation"
   arn       = aws_lambda_function.check_activation.arn
 }
@@ -32,5 +32,5 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_check_activation" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.check_activation.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.every_morning_at_7am.arn
+  source_arn    = aws_cloudwatch_event_rule.activation_every_hour.arn
 }

--- a/terraform/src/expiryJob.tf
+++ b/terraform/src/expiryJob.tf
@@ -15,14 +15,14 @@ resource "aws_lambda_function" "check_expiry" {
   role = aws_iam_role.readRole.arn
 }
 
-resource "aws_cloudwatch_event_rule" "every_morning_at_12am" {
-  name                = "every-morning-at-12am"
-  description         = "Fires every morning at 2pm UTC (12am Pacific)"
-  schedule_expression = "cron(5 7 * * ? *)"
+resource "aws_cloudwatch_event_rule" "expiry_every_hour" {
+  name                = "expiry-every-hour"
+  description         = "Fires hourly"
+  schedule_expression = "cron(0 * * * ? *)"
 }
 
-resource "aws_cloudwatch_event_target" "check_expiry_every_morning_at_12am" {
-  rule      = aws_cloudwatch_event_rule.every_morning_at_12am.name
+resource "aws_cloudwatch_event_target" "check_expiry_every_hour" {
+  rule      = aws_cloudwatch_event_rule.expiry_every_hour.name
   target_id = "check_expiry"
   arn       = aws_lambda_function.check_expiry.arn
 }
@@ -32,5 +32,5 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_check_expiry" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.check_expiry.function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.every_morning_at_12am.arn
+  source_arn    = aws_cloudwatch_event_rule.expiry_every_hour.arn
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3166,6 +3166,16 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns-tz@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.1.6.tgz#93cbf354e2aeb2cd312ffa32e462c1943cf20a8e"
+  integrity sha512-nyy+URfFI3KUY7udEJozcoftju+KduaqkVfwyTIE0traBiVye09QnyWKLZK7drRr5h9B7sPJITmQnS3U6YOdQg==
+
+date-fns@^2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.27.0.tgz#e1ff3c3ddbbab8a2eaadbb6106be2929a5a2d92b"
+  integrity sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==
+
 dayjs@^1.10.4, dayjs@^1.10.7:
   version "1.10.7"
   resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz"
@@ -6154,6 +6164,11 @@ mocha@^6.1.4:
     yargs "13.3.2"
     yargs-parser "13.1.2"
     yargs-unparser "1.6.0"
+
+mockdate@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
 
 module-definition@^3.3.1:
   version "3.3.1"


### PR DESCRIPTION
### Jira Ticket:

BRS-161

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-161

### Description:
Run the cron hourly, and set passes to active depending on pass type and facility opening hour:

AM - activates at facility opening hour (default pulled from config)
PM - activates at 12pm
DAY - activates at facility opening hour (default pulled from config)

Expiry runs hourly but doesn't depend on the facility:

AM - 12pm
PM - 12am
DAY - 12am

Hourly is a bit more resource intensive but means that we don't have to update the schedule around DST changes (when the offset from PT to UTC will be different).

Status changes will only happen the same day (or day after for PM/DAY) expiry, so should be resistant to a few cron failures, but not a longer outage.