### PR TITLE
NOBUG: set activation/expiry lambda timeouts to 5 min

### DIFF
--- a/terraform/src/activationJob.tf
+++ b/terraform/src/activationJob.tf
@@ -6,6 +6,7 @@ resource "aws_lambda_function" "check_activation" {
 
   handler = "lambda/checkActivation/index.handler"
   runtime = "nodejs14.x"
+  timeout = 300
 
   environment {
     variables = {

--- a/terraform/src/expiryJob.tf
+++ b/terraform/src/expiryJob.tf
@@ -6,6 +6,7 @@ resource "aws_lambda_function" "check_expiry" {
 
   handler = "lambda/checkExpiry/index.handler"
   runtime = "nodejs14.x"
+  timeout = 300
 
   environment {
     variables = {


### PR DESCRIPTION
These tasks run a lot of queries now, and have been timing out at 3 seconds.
