### PR TITLE
NOBUG: don't update existing passes in case of id collision

### DIFF
--- a/lambda/writePass/index.js
+++ b/lambda/writePass/index.js
@@ -9,7 +9,8 @@ const TABLE_NAME = process.env.TABLE_NAME || 'parksreso';
 
 exports.handler = async (event, context) => {
   let passObject = {
-    TableName: TABLE_NAME
+    TableName: TABLE_NAME,
+    ConditionExpression: 'attribute_not_exists(sk)',
   };
 
   if (!event) {


### PR DESCRIPTION
Because ids are randomly generated and `putItem` will update if the key exists, if a collision does happen, the old pass with that duplicated id will be overwritten with data from the new pass.

Collisions are unlikely to happen (1/100 000 000 initially I think), but become more likely with each pass issued, so it's possible it will happen a few times during the season.

Note that if this does happen the user will get a generic "Operation Failed" error, but a retry will probably succeed.

