### PR TITLE
NOBUG: Fixing facility edit duplication bug

### DIFF
--- a/lambda/writeFacility/index.js
+++ b/lambda/writeFacility/index.js
@@ -87,6 +87,7 @@ async function createFacility(obj) {
 
 async function updateFacility(obj) {
   let {
+    sk,
     parkName,
     bookingTimes,
     name,
@@ -117,7 +118,7 @@ async function updateFacility(obj) {
   let updateParams = {
     Key: {
       pk: { S: `facility::${parkName}` },
-      sk: { S: name }
+      sk: { S: sk }
     },
     ExpressionAttributeValues: {
       ':statusValue': { M: AWS.DynamoDB.Converter.marshall(status) },


### PR DESCRIPTION
### Description:

Fixing issue with facility edit. Instead of using name as the SK, we don't allow SK to change. This is related to https://github.com/bcgov/parks-reso-api/commit/cd0d2ff68bd92dc0495a9ebf436da2f35fae5587.
