### PR TITLE
NOBUG: Set default timeout a little bigger until we can get paginatio…

### DIFF
--- a/terraform/src/pass.tf
+++ b/terraform/src/pass.tf
@@ -17,6 +17,7 @@ resource "aws_lambda_function" "readPassLambda" {
 
   handler = "lambda/readPass/index.handler"
   runtime = "nodejs14.x"
+  timeout = 6
 
   environment {
     variables = {


### PR DESCRIPTION
…n working properly.  The lambda is running for slightly more than 3 seconds, therefore the function gets cancelled before it can complete.

### Jira Ticket:

NOBUG

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-123

### Description:

Fixes random 502's on the GETS for passes.  TODO: Paginate results instead.
