### PR TITLE
BRS-218: multiselect passStatus - API

### DIFF
--- a/lambda/readPass/index.js
+++ b/lambda/readPass/index.js
@@ -47,6 +47,19 @@ exports.handler = async (event, context) => {
         queryObj.ExpressionAttributeValues[':theDate'] = AWS.DynamoDB.Converter.input(dateselector);
         queryObj.FilterExpression += ' AND contains(#theDate, :theDate)';
       }
+      // Filter Multiple Statuses
+      if (event.queryStringParameters.passStatus) {
+        const statusList = event.queryStringParameters.passStatus.split(',');
+        const statusObj = {};
+        statusList.forEach((status, index) => {
+          const statusName = ":passStatus" + index;
+          statusObj[statusName.toString()] = AWS.DynamoDB.Converter.input(status);
+        });
+        queryObj = checkAddExpressionAttributeNames(queryObj);
+        queryObj.ExpressionAttributeNames['#theStatus'] = 'passStatus';
+        Object.assign(queryObj.ExpressionAttributeValues, statusObj);
+        queryObj.FilterExpression += ' AND #theStatus IN (' + Object.keys(statusObj).toString() + ')';
+      }
       // Filter reservation number
       if (event.queryStringParameters.reservationNumber) {
         queryObj.ExpressionAttributeValues[':sk'] = { S: event.queryStringParameters.reservationNumber };

--- a/lambda/readPass/index.js
+++ b/lambda/readPass/index.js
@@ -51,10 +51,10 @@ exports.handler = async (event, context) => {
       if (event.queryStringParameters.passStatus) {
         const statusList = event.queryStringParameters.passStatus.split(',');
         const statusObj = {};
-        statusList.forEach((status, index) => {
+        for (let [index, status] of statusList.entries()) {
           const statusName = ":passStatus" + index;
           statusObj[statusName.toString()] = AWS.DynamoDB.Converter.input(status);
-        });
+        }
         queryObj = checkAddExpressionAttributeNames(queryObj);
         queryObj.ExpressionAttributeNames['#theStatus'] = 'passStatus';
         Object.assign(queryObj.ExpressionAttributeValues, statusObj);


### PR DESCRIPTION
### Jira Ticket:

BRS-218

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-218

### Description:

This change adds API functionality to filter `readPass` results by `passStatus`.

To filter by one type of `passStatus`, 'active' for example:
* `GET .../api/pass?park=parkName&facilityName=facilityName&passStatus=active`

To filter by mutliple types of `passStatus`:
* `GET .../api/pass?park=parkName&facilityName=facilityName&passStatus=expired,cancelled,reserved`
