### PR TITLE
BRS-294: passStatus set to active if booking during active hours

### DIFF
--- a/__tests__/writePass.test.js
+++ b/__tests__/writePass.test.js
@@ -215,6 +215,43 @@ describe('Pass Fails', () => {
       }
     );
   });
+  
+  test('Handler - 400 Bad Request - Booking date in the past', async () => {
+    let yesterday = new Date();
+    yesterday = yesterday.setDate(yesterday.getDate()-1);
+
+    const event = {
+      body: JSON.stringify({
+        parkName: '',
+        firstName: '',
+        lastName: '',
+        facilityName: '',
+        email: '',
+        date: new Date(yesterday),
+        type: '',
+        numberOfGuests: 1,
+        phoneNumber: '',
+        facilityType: '',
+        license: '',
+        captchaJwt: token
+      })
+    };
+    expect(await writePassHandler.handler(event, null)).toMatchObject(
+      {
+        "body": JSON.stringify({
+          msg: "You cannot book for a date in the past.",
+          title: "Booking date in the past"
+        }),
+        "headers": {
+          "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
+          "Access-Control-Allow-Methods": "OPTIONS,GET",
+          "Access-Control-Allow-Origin": "*",
+          "Content-Type": "application/json"
+        },
+        "statusCode": 400
+      }
+    );
+  });
 
   test('Handler - 400 Bad Request - One or more params are invalid.', async () => {
     const event = {
@@ -271,7 +308,7 @@ describe('Pass Successes', () => {
         facilityName: 'Parking lot A',
         email: 'noreply@gov.bc.ca',
         date: new Date(),
-        type: 'AM',
+        type: 'DAY',
         numberOfGuests: 1,
         phoneNumber: '2505555555',
         facilityType: 'Trail',
@@ -290,10 +327,10 @@ describe('Pass Successes', () => {
     expect(body.facilityName).toEqual('Parking lot A');
     expect(body.email).toEqual('noreply@gov.bc.ca');
     expect(typeof body.date).toBe('string');
-    expect(body.type).toEqual('AM');
+    expect(body.type).toEqual('DAY');
     expect(typeof body.registrationNumber).toBe('string');
     expect(body.numberOfGuests).toEqual(1);
-    expect(body.passStatus).toEqual('reserved');
+    expect(['reserved','active']).toContain(body.passStatus);
     expect(body.phoneNumber).toEqual('2505555555');
     expect(body.facilityType).toEqual('Trail');
     expect(typeof body.err).toBe('string');
@@ -308,7 +345,7 @@ describe('Pass Successes', () => {
         facilityName: 'Parking lot A',
         email: 'noreply@gov.bc.ca',
         date: new Date(),
-        type: 'AM',
+        type: 'DAY',
         numberOfGuests: 1,
         phoneNumber: '2505555555',
         facilityType: 'Parking',
@@ -328,10 +365,10 @@ describe('Pass Successes', () => {
     expect(body.facilityName).toEqual('Parking lot A');
     expect(body.email).toEqual('noreply@gov.bc.ca');
     expect(typeof body.date).toBe('string');
-    expect(body.type).toEqual('AM');
+    expect(body.type).toEqual('DAY');
     expect(typeof body.registrationNumber).toBe('string');
     expect(body.numberOfGuests).toEqual(1);
-    expect(body.passStatus).toEqual('reserved');
+    expect(['reserved','active']).toContain(body.passStatus);
     expect(body.phoneNumber).toEqual('2505555555');
     expect(body.facilityType).toEqual('Parking');
     expect(typeof body.err).toBe('string');
@@ -366,10 +403,14 @@ async function databaseOperation(version, mode) {
               "AM": {
                 "max": 25
               },
+              "DAY": {
+                "max": 25
+              },
             },
             "reservations": {
               "20211207": {
-                "AM": 1
+                "AM": 1,
+                "DAY": 1
               }
             },
             "status": "open",

--- a/__tests__/writePass.test.js
+++ b/__tests__/writePass.test.js
@@ -217,17 +217,14 @@ describe('Pass Fails', () => {
   });
   
   test('Handler - 400 Bad Request - Booking date in the past', async () => {
-    let yesterday = new Date();
-    yesterday = yesterday.setDate(yesterday.getDate()-1);
-
-    const event = {
+   const event = {
       body: JSON.stringify({
         parkName: '',
         firstName: '',
         lastName: '',
         facilityName: '',
         email: '',
-        date: new Date(yesterday),
+        date: "1970-01-01T00:00:00.758Z",
         type: '',
         numberOfGuests: 1,
         phoneNumber: '',

--- a/lambda/writePass/index.js
+++ b/lambda/writePass/index.js
@@ -7,6 +7,10 @@ const { sendResponse } = require('../responseUtil');
 
 const TABLE_NAME = process.env.TABLE_NAME || 'parksreso';
 
+// default opening/closing hours in 24h time
+const DEFAULT_AM_OPENING_HOUR = 7;
+const DEFAULT_PM_OPENING_HOUR = 12;
+
 exports.handler = async (event, context) => {
   let passObject = {
     TableName: TABLE_NAME,
@@ -72,6 +76,63 @@ exports.handler = async (event, context) => {
       numberOfGuests = 1;
     }
 
+    // Get current time vs booking time information
+    const today = new Date();
+    const currentDay = parseInt(today.toLocaleString('en-US', { day: '2-digit', timeZone: 'America/Vancouver' }));
+    const currentHour = parseInt(
+      today.toLocaleString('en-US', { hour: '2-digit', hour12: false, timeZone: 'America/Vancouver' })
+    );
+    const bookingDay = new Date(date).getDate();
+
+    let facilityObj = {
+      TableName: TABLE_NAME
+    };
+
+    // check if booking date in the past
+    if (currentDay > bookingDay) {
+      return sendResponse(400, {
+        msg: 'You cannot book for a date in the past.',
+        title: 'Booking date in the past'
+      });
+    }
+    
+    facilityObj.ExpressionAttributeValues = {};
+    facilityObj.ExpressionAttributeValues[':pk'] = { S: 'facility::' + parkName };
+    facilityObj.ExpressionAttributeValues[':sk'] = { S: facilityName };
+    facilityObj.KeyConditionExpression = 'pk =:pk AND sk =:sk';
+    const facilityData = await runQuery(facilityObj);
+    console.log('FacilityData:', facilityData);
+
+    // There should only be 1 facility.
+    let openingHour = facilityData[0].bookingOpeningHour || DEFAULT_AM_OPENING_HOUR;
+    let closingHour = DEFAULT_PM_OPENING_HOUR;
+
+
+    let status = 'reserved';
+
+    // check if booking same-day
+    if (currentDay === bookingDay) {
+      // check if AM/PM/DAY is currently open
+      if (type === 'AM' && currentHour >= DEFAULT_PM_OPENING_HOUR) {
+        // it is beyond AM closing time
+        return sendResponse(400, {
+          msg:
+            'It is too late to book an AM pass on this day (AM time slot is from ' +
+            to12hTimeString(openingHour) +
+            ' to ' +
+            to12hTimeString(closingHour) +
+            ').',
+          title: 'AM time slot has expired'
+        });
+      }
+      if (type === 'PM') {
+        openingHour = DEFAULT_PM_OPENING_HOUR;
+      }
+      if (currentHour >= openingHour) {
+        status = 'active';
+      }
+    }
+
     passObject.Item = {};
     passObject.Item['pk'] = { S: 'pass::' + parkName };
     passObject.Item['sk'] = { S: registrationNumber };
@@ -83,7 +144,7 @@ exports.handler = async (event, context) => {
     passObject.Item['type'] = { S: type };
     passObject.Item['registrationNumber'] = { S: registrationNumber };
     passObject.Item['numberOfGuests'] = AWS.DynamoDB.Converter.input(numberOfGuests);
-    passObject.Item['passStatus'] = { S: 'reserved' };
+    passObject.Item['passStatus'] = { S: status };
     passObject.Item['phoneNumber'] = AWS.DynamoDB.Converter.input(phoneNumber);
     passObject.Item['facilityType'] = { S: facilityType };
 
@@ -296,6 +357,18 @@ exports.handler = async (event, context) => {
     return sendResponse(400, { msg: 'Something went wrong.', title: 'Operation Failed' });
   }
 };
+
+function to12hTimeString(hour) {
+  let period = 'am';
+  if (hour > 11) {
+    period = 'pm';
+    if (hour > 12) {
+      hour -= 12;
+    }
+  }
+  let hourStr = hour === 0 ? '12' : hour.toString();
+  return hourStr + period;
+}
 
 function generate(count) {
   // TODO: Make this better

--- a/lambda/writePass/index.js
+++ b/lambda/writePass/index.js
@@ -79,22 +79,22 @@ exports.handler = async (event, context) => {
 
     // Get current time vs booking time information
     const localDate = utcToZonedTime(Date.now(), 'America/Vancouver');
-    const currentHour = localDate.getHours();  
+    const currentHour = localDate.getHours();
     const bookingDate = new Date(date);
-    console.log('localDate', localDate, 'bookingDate', bookingDate);
 
     let facilityObj = {
       TableName: TABLE_NAME
     };
 
     // check if booking date in the past
-    if (localDate > bookingDate && localDate.getDate() > bookingDate.getDate()) {
+    localDate.setHours(0,0,0,0);
+    if (localDate > bookingDate) {
       return sendResponse(400, {
         msg: 'You cannot book for a date in the past.',
         title: 'Booking date in the past'
       });
     }
-    
+
     facilityObj.ExpressionAttributeValues = {};
     facilityObj.ExpressionAttributeValues[':pk'] = { S: 'facility::' + parkName };
     facilityObj.ExpressionAttributeValues[':sk'] = { S: facilityName };
@@ -104,7 +104,6 @@ exports.handler = async (event, context) => {
     // There should only be 1 facility.
     let openingHour = facilityData[0].bookingOpeningHour || DEFAULT_AM_OPENING_HOUR;
     let closingHour = DEFAULT_PM_OPENING_HOUR;
-
 
     let status = 'reserved';
 


### PR DESCRIPTION
### Jira Ticket:

BRS-294

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-294

### Description:

This change sets `passStatus` to `active` when creating/booking a pass during active hours. 

Currently the default action is to set `passStatus` to `reserved` regardless of when the pass is created/booked. This is causing active passes incorrectly marked as `reserved` to be overlooked by the crons, therefore never getting set to `active` or `expired`. This causes passes that should be expired to appear as reserved.

Additionally, the API still allows passes to be booked for days that have already passed, or for AM passes to be booked after the PM timeslot begins. This change adds API functionality to check and reject booking requests for times that fall outside of reservable/active hours.

The test suite has been updated to capture some of the new functionality
