### PR TITLE
BRS-468: Bump memory limit for more vCPU

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -148,6 +148,7 @@ functions:
   ###########
   metric:
     handler: lambda/metric/index.handler
+    memory: 1792
     events:
       - http:
           method: GET


### PR DESCRIPTION
### Jira Ticket:

BRS-468

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-468

### Description:

Site metrics on DUP showing error message and not loading.  This bumps the memory up so we get more vCPUin our lambda.  New execution time is < 6000ms