### PR TITLE
BRS-296-2: showing date in more places

### DIFF
--- a/lambda/readPass/index.js
+++ b/lambda/readPass/index.js
@@ -167,10 +167,18 @@ exports.handler = async (event, context) => {
           token;
 
         const encodedCancellationLink = encodeURI(cancellationLink);
+        const dateOptions = { day: 'numeric', month: 'long', year: 'numeric' };
+        let formattedDate = new Date(passData.data[0].date).toLocaleDateString('en-US', dateOptions);
+        if (passData.data[0].type) {
+          formattedDate += ' (' + passData.data[0].type + ')'
+        }
 
         let personalisation = {
           registrationNumber: passData.data[0].registrationNumber.toString(),
-          link: encodedCancellationLink
+          link: encodedCancellationLink,
+          date: formattedDate,
+          parkName: passData.data[0].pk.split('::')[1] || '',
+          facilityName: passData.data[0].facilityName || ''
         };
 
         // Send email

--- a/lambda/writePass/index.js
+++ b/lambda/writePass/index.js
@@ -161,7 +161,11 @@ exports.handler = async (event, context) => {
       '&email=' +
       email +
       '&park=' +
-      parkName;
+      parkName + 
+      '&date=' +
+      dateselector + 
+      '&type=' +
+      type;
 
     const encodedCancellationLink = encodeURI(cancellationLink);
 


### PR DESCRIPTION
### Jira Ticket:

BRS-296

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-296

### Description:
Some screens were missed in the original change. API now passes `date` and `type` to the intermediate cancellation screen via the URL. It also passes `parkName`, `facilityName` and `date` to the GCN API when triggering cancellation emails.

##IMPORTANT: GCN PROD cancellation email templates need updating upon this change hitting the PROD env.

Note: this PR should be passed before https://github.com/bcgov/parks-reso-public/pull/129