### PR TITLE
BRS-658 fixing time zone issues for writePass.js

### DIFF
--- a/__tests__/writePass.test.js
+++ b/__tests__/writePass.test.js
@@ -234,7 +234,7 @@ describe('Pass Successes', () => {
         firstName: 'Jest',
         lastName: 'User',
         facilityName: 'Parking lot A',
-        email: 'noreply@gov.bc.ca',
+        email: 'testEmail1@test.ca',
         date: new Date(),
         type: 'DAY',
         numberOfGuests: 1,
@@ -252,7 +252,7 @@ describe('Pass Successes', () => {
     expect(body.firstName).toEqual('Jest');
     expect(body.lastName).toEqual('User');
     expect(body.facilityName).toEqual('Parking lot A');
-    expect(body.email).toEqual('noreply@gov.bc.ca');
+    expect(body.email).toEqual('testEmail1@test.ca');
     expect(typeof body.date).toBe('string');
     expect(body.type).toEqual('DAY');
     expect(typeof body.registrationNumber).toBe('string');
@@ -270,7 +270,7 @@ describe('Pass Successes', () => {
         firstName: 'Jest',
         lastName: 'User',
         facilityName: 'Parking lot A',
-        email: 'noreply@gov.bc.ca',
+        email: 'testEmail2@test.ca',
         date: new Date(),
         type: 'DAY',
         numberOfGuests: 1,
@@ -289,7 +289,7 @@ describe('Pass Successes', () => {
     expect(body.firstName).toEqual('Jest');
     expect(body.lastName).toEqual('User');
     expect(body.facilityName).toEqual('Parking lot A');
-    expect(body.email).toEqual('noreply@gov.bc.ca');
+    expect(body.email).toEqual('testEmail2@test.ca');
     expect(typeof body.date).toBe('string');
     expect(body.type).toEqual('DAY');
     expect(typeof body.registrationNumber).toBe('string');


### PR DESCRIPTION
### Jira Ticket:

BRS-658 

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-658

### Description:
This change is part 1 of several that involve fortifying the back end against time zone spoofing. 

This change addresses the 4 time zone issue outlined in https://bcparksdigital.atlassian.net/browse/BRS-651 for our `writePass` lambda only. The packages `date-fns` and `date-fns-tz` are removed and replaced with `luxon`. 

Additionally, the portion of `writePass` that checks for existing passes was fortified to check only the date portion of the ISO date object so that each email address may have a maximum of 1 pass per given day (before, passes booking for `2022-06-09T19:00:00.000Z` and `2022-06-09T19:00:01.000Z` would fail the 'same-day' check).
