### PR TITLE
BRS-658: fixing time zone issues in readPass.js

### DIFF
--- a/lambda/readPass/index.js
+++ b/lambda/readPass/index.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 const { runQuery, TABLE_NAME, expressionBuilder } = require('../dynamoUtil');
 const { sendResponse } = require('../responseUtil');
 const { decodeJWT, resolvePermissions } = require('../permissionUtil');
-const { formatISO } = require('date-fns');
+const { DateTime } = require('luxon');
 
 exports.handler = async (event, context) => {
   console.log('Read Pass', event);
@@ -30,7 +30,7 @@ exports.handler = async (event, context) => {
       // Get all the passes for a specific facility
       if (event.queryStringParameters.date) {
         // Use GSI on shortPassDate if date is provided
-        const shortDate = formatISO(new Date(event.queryStringParameters.date), { representation: 'date' });
+        const shortDate = DateTime.fromISO(event.queryStringParameters.date).toISODate();
 
         queryObj.ExpressionAttributeValues = {};
         queryObj.IndexName = 'shortPassDate-index';
@@ -145,7 +145,7 @@ exports.handler = async (event, context) => {
       console.log('passData', passData);
 
       if (passData && passData.data && passData.data.length !== 0) {
-        const dateselector = formatISO(new Date(passData.data[0].date), { representation: 'date' });
+        const dateselector = DateTime.fromISO(passData.data[0].date).toISODate();
 
         // Build cancellation email payload
         const claims = {
@@ -172,7 +172,7 @@ exports.handler = async (event, context) => {
 
         const encodedCancellationLink = encodeURI(cancellationLink);
         const dateOptions = { day: 'numeric', month: 'long', year: 'numeric' };
-        let formattedDate = new Date(passData.data[0].date).toLocaleDateString('en-US', dateOptions);
+        let formattedDate = DateTime.fromISO(passData.data[0].date).toLocaleString(dateOptions);
         if (passData.data[0].type) {
           let formattedType = passData.data[0].type === 'DAY' ? 'ALL DAY' : passData.data[0].type;
           formattedDate += ' (' + formattedType + ')'


### PR DESCRIPTION
### Jira Ticket:

BRS-658

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-658

### Description:
This change is part 2 of several that involve fortifying the back end against time zone spoofing.

This change addresses the 4 time zone issue outlined in https://bcparksdigital.atlassian.net/browse/BRS-651 for our `readPass` lambda only. The packages `date-fns` and `date-fns-tz` are removed and replaced with `luxon`.
