### PR TITLE
BRS-658 fixing time zone issues in checkExpiry.js

### DIFF
--- a/__tests__/checkExpiry.test.js
+++ b/__tests__/checkExpiry.test.js
@@ -1,5 +1,5 @@
 const MockDate = require('mockdate');
-const { formatISO } = require('date-fns');
+const { DateTime } = require('luxon');
 const AWS = require('aws-sdk');
 const { DocumentClient } = require('aws-sdk/clients/dynamodb');
 
@@ -60,7 +60,7 @@ describe('checkExpiryHandler', () => {
   });
 
   test.each([['AM', '123456710'], ['PM', '123456711'], ['DAY', '123456712']])('should set %s passes from yesterday to expired', async (passType, sk) => {
-    const passDate = new Date('2021-12-08T20:00:00.000Z');
+    const passDate = DateTime.fromISO('2021-12-08T20:00:00.000Z');
     await docClient
       .put({
         TableName: TABLE_NAME,
@@ -71,7 +71,7 @@ describe('checkExpiryHandler', () => {
           type: passType,
           registrationNumber: sk,
           passStatus: 'active',
-          date: formatISO(passDate)
+          date: passDate.toISO()
         }
       })
       .promise();
@@ -93,7 +93,7 @@ describe('checkExpiryHandler', () => {
   });
 
   test.each([['PM', '123456713'], ['DAY', '123456714']])('should not set %s passes from today to expired', async (passType, sk) => {
-    const passDate = new Date('2021-12-08T20:00:00.000Z');
+    const passDate = DateTime.fromISO('2021-12-08T20:00:00.000Z');
     await docClient
       .put({
         TableName: TABLE_NAME,
@@ -104,7 +104,7 @@ describe('checkExpiryHandler', () => {
           type: passType,
           registrationNumber: sk,
           passStatus: 'active',
-          date: formatISO(passDate)
+          date: passDate.toISO()
         }
       })
       .promise();
@@ -126,7 +126,7 @@ describe('checkExpiryHandler', () => {
   });
 
   test('should set AM passes to expired after 12:00', async () => {
-    const passDate = new Date('2021-12-08T20:00:00.000Z');
+    const passDate = DateTime.fromISO('2021-12-08T20:00:00.000Z');
     await docClient
       .put({
         TableName: TABLE_NAME,
@@ -137,7 +137,7 @@ describe('checkExpiryHandler', () => {
           type: 'AM',
           registrationNumber: '123456715',
           passStatus: 'active',
-          date: formatISO(passDate)
+          date: passDate.toISO()
         }
       })
       .promise();
@@ -159,7 +159,7 @@ describe('checkExpiryHandler', () => {
   });
 
   test('should set not AM passes to expired before 12:00', async () => {
-    const passDate = new Date('2021-12-08T20:00:00.000Z');
+    const passDate = DateTime.fromISO('2021-12-08T20:00:00.000Z');
     await docClient
       .put({
         TableName: TABLE_NAME,
@@ -170,7 +170,7 @@ describe('checkExpiryHandler', () => {
           type: 'AM',
           registrationNumber: '123456716',
           passStatus: 'active',
-          date: formatISO(passDate)
+          date: passDate.toISO()
         }
       })
       .promise();

--- a/lambda/checkExpiry/index.js
+++ b/lambda/checkExpiry/index.js
@@ -1,35 +1,41 @@
 const { compareAsc, addHours, endOfYesterday, startOfDay } = require('date-fns');
 const { utcToZonedTime } = require('date-fns-tz');
+const { DateTime } = require('luxon');
 const { getPassesByStatus,
-        setStatus,
-        ACTIVE_STATUS,
-        EXPIRED_STATUS,
-        PASS_TYPE_EXPIRY_HOURS,
-        PASS_TYPE_AM,
-        timeZone } = require('../dynamoUtil');
+  setStatus,
+  ACTIVE_STATUS,
+  EXPIRED_STATUS,
+  PASS_TYPE_EXPIRY_HOURS,
+  PASS_TYPE_AM,
+  TIMEZONE } = require('../dynamoUtil');
 const { sendResponse } = require('../responseUtil');
 
 exports.handler = async (event, context) => {
   console.log('Check Expiry', event, context);
+  console.log('Server Time Zone:',
+    Intl.DateTimeFormat().resolvedOptions().timeZone || 'undefined',
+    `(${DateTime.now().toISO()})`
+  );
   try {
-    const endOfYesterdayTime = endOfYesterday();
-    const currentTime = utcToZonedTime(new Date(), timeZone);
+    const currentPSTDateTime = DateTime.now().setZone(TIMEZONE);
+    const yesterdayEndPSTDateTime = currentPSTDateTime.minus({ days: 1 }).endOf('day');
 
     let passesToChange = [];
     const passes = await getPassesByStatus(ACTIVE_STATUS);
     console.log("Active Passes:", passes);
 
-    for(pass of passes) {
-      const zonedPassTime = utcToZonedTime(pass.date, timeZone);
-      // If it's zoned date is before the end of yesterday, it's definitely expired (AM/PM/DAY)
-      if (compareAsc(zonedPassTime, endOfYesterdayTime) <= 0) {
+    for (pass of passes) {
+      // NOTE: Pass dates are stored in UTC. 
+      // If pass date converted to PST is before the end of yesterday, it's definitely expire (AM/PM/DAY)
+      const passPSTDateTime = DateTime.fromISO(pass.date).setZone(TIMEZONE);
+      if (passPSTDateTime <= yesterdayEndPSTDateTime){
         console.log("Expiring:", pass);
         passesToChange.push(pass);
       }
 
       // If AM, see if we're currently in the afternoon or later compared to the pass date's noon time.
-      const noonTime = addHours(startOfDay(zonedPassTime), PASS_TYPE_EXPIRY_HOURS.AM);
-      if (pass.type === PASS_TYPE_AM && compareAsc(currentTime, noonTime) > 0) {
+      const passAMExpiryPSTDateTime = currentPSTDateTime.startOf('day').plus({hours: PASS_TYPE_EXPIRY_HOURS.AM});
+      if (pass.type === PASS_TYPE_AM && currentPSTDateTime >= passAMExpiryPSTDateTime){
         console.log("Expiring:", pass);
         passesToChange.push(pass);
       }


### PR DESCRIPTION
### Jira Ticket:

BRS-658

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-658

### Description:

This change is part 3 of several that involve fortifying the back end against time zone spoofing.

This change addresses the 4 time zone issue outlined in https://bcparksdigital.atlassian.net/browse/BRS-651 for our checkExpiry lambda only. The packages `date-fns` and `date-fns-tz` are removed and replaced with `luxon`.

This change addresses a bug where tests would fail if they were run late in the day PST time (next day UTC dates were causing issues). 

The `mockdate` package was investigated and found to be NOT succeptable to the same `date-fns`/`date-fns-tz` issues related to BRS-658.
