### PR TITLE
NOBUG adding pass creation timestamp

### DIFF
--- a/lambda/writePass/index.js
+++ b/lambda/writePass/index.js
@@ -173,6 +173,7 @@ exports.handler = async (event, context) => {
     passObject.Item['passStatus'] = { S: status };
     passObject.Item['phoneNumber'] = AWS.DynamoDB.Converter.input(phoneNumber);
     passObject.Item['facilityType'] = { S: facilityType };
+    passObject.Item['creationDate'] = {S: currentPSTDateTime.toUTC().toISO() };
 
     const cancellationLink =
       process.env.PUBLIC_FRONTEND +


### PR DESCRIPTION
### Jira Ticket:

NOBUG

### Description:

We dont currently store a timestamp for the creation time of passes. This will be useful in the future if we need to know the order in which passes were booked.
