### PR TITLE
BRS-658 removing duplicate timezone declarations in dynamoUtil

### DIFF
--- a/lambda/dynamoUtil.js
+++ b/lambda/dynamoUtil.js
@@ -11,7 +11,6 @@ if (process.env.IS_OFFLINE) {
 const ACTIVE_STATUS = 'active';
 const RESERVED_STATUS = 'reserved';
 const EXPIRED_STATUS = 'expired';
-const timeZone = 'America/Vancouver';
 const PASS_TYPE_AM = 'AM';
 const PASS_TYPE_PM = 'PM';
 const PASS_TYPE_DAY = 'DAY';
@@ -186,7 +185,6 @@ module.exports = {
   PM_ACTIVATION_HOUR,
   PASS_TYPE_EXPIRY_HOURS,
   TIMEZONE,
-  timeZone,
   TABLE_NAME,
   dynamodb,
   setStatus,


### PR DESCRIPTION
### Jira Ticket:

BRS-658

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-658

### Description:

`timeZone` and `TIMEZONE` both equal the same thing.