### PR TITLE
BRS-719 adding readReservation lambda

### DIFF
--- a/lambda/readReservation/index.js
+++ b/lambda/readReservation/index.js
@@ -1,0 +1,210 @@
+const { runQuery, TABLE_NAME, DEFAULT_BOOKING_DAYS_AHEAD, TIMEZONE } = require('../dynamoUtil');
+const { sendResponse } = require('../responseUtil');
+const { decodeJWT, resolvePermissions, roleFilter } = require('../permissionUtil');
+const { logger } = require('../logger');
+const { DateTime } = require('luxon');
+
+// TODO: provide these as vars in Parameter Store
+const LOW_CAPACITY_THRESHOLD = process.env.LOW_CAPACITY_THRESHOLD || 0.25;
+const MODERATE_CAPACITY_THRESHOLD = process.env.MODERATE_CAPACITY_THRESHOLD || 0.75;
+
+exports.handler = async (event, context) => {
+  logger.debug('Read Facility', event);
+  logger.debug('event.queryStringParameters', event.queryStringParameters);
+
+  const token = await decodeJWT(event);
+  const permissionObject = resolvePermissions(token);
+
+  try {
+    if (!event.queryStringParameters) {
+      return sendResponse(400, { msg: 'Invalid Request' }, context);
+    }
+
+    let park = {};
+    let facility = {};
+    let date = '';
+
+    // Check permissions against requested reservations object
+    // If public, we have to check some aspects of the park & facility first.
+    if (!permissionObject.isAuthenticated) {
+      logger.debug('**NOT AUTHENTICATED, PUBLIC**');
+      // Public queries require a date.
+      if (!event.queryStringParameters.date || new Date(event.queryStringParameters.date).toString() === 'Invalid Date') {
+        return sendResponse(400, { msg: 'A valid date must be provided' }, context);
+      }
+
+      date = event.queryStringParameters.date;
+      park = await getPark(event.queryStringParameters.park);
+      if (park.length < 1) {
+        return sendResponse(404, { msg: 'Park not found' }, context);
+      };
+      facility = await getFacility(event.queryStringParameters.park, event.queryStringParameters.facility);
+      if (facility.length < 1) {
+        return sendResponse(404, { msg: 'Facility not found' }, context);
+      }
+
+      // Don't return any dates to the public in the past or beyond the lookahead date.
+      const lookAheadDays = facility.bookingDaysAhead || DEFAULT_BOOKING_DAYS_AHEAD;
+      const todayDateTime = DateTime.now().setZone(TIMEZONE);
+      const lookAheadDate = todayDateTime.plus({ days: lookAheadDays }).toISODate();
+      if (date > lookAheadDate) {
+        return sendResponse(400, { msg: `Date must be at most ${lookAheadDays} day(s) in the future` }, context);
+      } else if (date < todayDateTime.toISODate()) {
+        return sendResponse(400, { msg: 'Date cannot be in the past' }, context);
+      }
+    }
+
+    // if authorized but not sysadmin, we need to check park roles.
+    if (permissionObject.isAuthenticated && !permissionObject.isAdmin) {
+      logger.debug('**AUTHORIZED, NOT SYSADMIN**');
+      park = await getPark(event.queryStringParameters.park);
+      logger.debug('Roles:', permissionObject.roles);
+      park = await roleFilter(park, permissionObject.roles);
+      // if user does not have correct park role, then they are not authorized. 
+      if (park.length < 1) {
+        return sendResponse(403, { msg: 'Unauthorized' }, context);
+      }
+    }
+
+    // build the reservation query object
+    if (event.queryStringParameters.park && event.queryStringParameters.facility) {
+      logger.debug('Grab reservations for facility:', event.queryStringParameters.facility);
+      let queryObj = {
+        TableName: TABLE_NAME,
+        ConsistentRead: true,
+        ExpressionAttributeNames: {
+          '#pk': 'pk'
+        },
+        ExpressionAttributeValues: {
+          ':pk': { S: `reservations::${event.queryStringParameters.park}::${event.queryStringParameters.facility}` }
+        },
+        KeyConditionExpression: '#pk = :pk'
+      };
+
+      // if we are searching for a specific date
+      if (event.queryStringParameters.date) {
+        queryObj.ExpressionAttributeNames['#sk'] = 'sk';
+        queryObj.ExpressionAttributeValues[':date'] = { S: event.queryStringParameters.date };
+        queryObj.KeyConditionExpression += ' AND #sk = :date';
+      }
+
+      let reservations = await runQuery(queryObj);
+
+      // format/filter results based on permissions
+      if (!permissionObject.isAuthenticated) {
+        // public receives a heavily filtered payload
+        reservations = formatPublicResults(reservations[0], facility[0], date);
+      } else if (permissionObject.isAdmin) {
+        // Return everything to sysadmins
+        logger.debug('**SYSADMIN**');
+      }
+
+      logger.debug('GET reservations:', reservations)
+      return sendResponse(200, reservations);
+    }
+  } catch (err) {
+    logger.error('ERROR:', err);
+    return sendResponse(400, {msg: err}, context);
+  }
+};
+
+async function getPark(park) {
+  try {
+    let queryObj = {
+      TableName: TABLE_NAME,
+      ConsistentRead: true,
+      ExpressionAttributeNames: {
+        '#pk': 'pk',
+        '#sk': 'sk',
+        '#visible': 'visible'
+      },
+      ExpressionAttributeValues: {
+        ':pk': { S: 'park' },
+        ':sk': { S: park },
+        ':visible': { BOOL: true }
+      },
+      KeyConditionExpression: '#pk = :pk AND #sk = :sk',
+      FilterExpression: '#visible = :visible'
+    }
+
+    res = await runQuery(queryObj);
+    if (!res) {
+      throw 'Park was not found.';
+    }
+    logger.debug('Public reservations - GET park:', res);
+    return res;
+  } catch (err) {
+    logger.error('ERROR:', err);
+    return {};
+  }
+}
+
+async function getFacility(park, facility) {
+  try {
+    let queryObj = {
+      TableName: TABLE_NAME,
+      ConsistentRead: true,
+      ExpressionAttributeNames: {
+        '#pk': 'pk',
+        '#sk': 'sk',
+        '#visible': 'visible'
+      },
+      ExpressionAttributeValues: {
+        ':pk': { S: `facility::${park}` },
+        ':sk': { S: facility },
+        ':visible': { BOOL: true }
+      },
+      KeyConditionExpression: '#pk = :pk AND #sk = :sk',
+      FilterExpression: '#visible = :visible'
+    };
+
+    res = await runQuery(queryObj);
+    if (!res) {
+      throw 'Facility was not found.';
+    }
+    logger.debug('Public reservations - GET facility:', res);
+    return res;
+  } catch (err) {
+    logger.error('ERROR:', err);
+    return {};
+  }
+}
+
+// Remove fields from public results.
+function formatPublicResults(reservations, facility, date) {
+  let publicObj = {};
+  // Sanity check - if there is no date, send back empty object - public must provide date.
+  if (!date) {
+    return publicObj;
+  }
+  // If there is a facility but no reservation object, we can assume there are no reservations yet for the date.
+  // We can prepopulate the results with a template of the facility's capacities.
+  if (facility) {
+    for (const key of Object.keys(facility.bookingTimes)) {
+      publicObj[key] = 'High';
+    }
+  }
+  // If we have a reservation object, overwrite the facility capacity template with reservation object values.
+  if (reservations) {
+    for (const [key, value] of Object.entries(reservations.capacities)) {
+      publicObj[key] = getCapacityLevel(value.baseCapacity, value.availablePasses, value.capacityModifier);
+    }
+  }
+  return publicObj;
+};
+
+// Get capacity level (high, med, low, none) of a facility.
+function getCapacityLevel(base, available, modifier) {
+  const capacity = base + modifier;
+  const booked = capacity - available;
+  const percentage = booked / capacity;
+  if (percentage < LOW_CAPACITY_THRESHOLD) {
+    return 'High';
+  } else if (percentage < MODERATE_CAPACITY_THRESHOLD) {
+    return 'Moderate';
+  } else if (percentage < 1) {
+    return 'Low';
+  } else {
+    return 'Full';
+  }
+};

--- a/lambda/readReservation/index.js
+++ b/lambda/readReservation/index.js
@@ -12,14 +12,14 @@ exports.handler = async (event, context) => {
   logger.debug('Read Facility', event);
   logger.debug('event.queryStringParameters', event.queryStringParameters);
 
-  const token = await decodeJWT(event);
-  const permissionObject = resolvePermissions(token);
-
   try {
     if (!event.queryStringParameters) {
       return sendResponse(400, { msg: 'Invalid Request' }, context);
     }
 
+    const token = await decodeJWT(event);
+    const permissionObject = resolvePermissions(token);
+    
     let park = {};
     let facility = {};
     let date = '';

--- a/lambda/readReservation/index.js
+++ b/lambda/readReservation/index.js
@@ -19,29 +19,40 @@ exports.handler = async (event, context) => {
 
     const token = await decodeJWT(event);
     const permissionObject = resolvePermissions(token);
-    
-    let park = {};
+
     let facility = {};
-    let date = '';
 
     // Check permissions against requested reservations object
-    // If public, we have to check some aspects of the park & facility first.
-    if (!permissionObject.isAuthenticated) {
+    if (permissionObject.isAuthenticated) {
+      if (permissionObject.isAdmin) {
+        logger.debug('**SYSADMIN**');
+      } else {
+        logger.debug('**AUTHENTICATED, NOT SYSADMIN**');
+        let park = await getPark(event.queryStringParameters.park, true);
+        // check roles. 
+        logger.debug('Roles:', permissionObject.roles);
+        park = await roleFilter(park, permissionObject.roles);
+        // if user does not have correct park role, then they are not authorized. 
+        if (park.length < 1) {
+          return sendResponse(403, { msg: 'Unauthorized' }, context);
+        };
+      };
+    } else {
+      // If public, we have to check some aspects of the park & facility first.
       logger.debug('**NOT AUTHENTICATED, PUBLIC**');
       // Public queries require a date.
       if (!event.queryStringParameters.date || new Date(event.queryStringParameters.date).toString() === 'Invalid Date') {
         return sendResponse(400, { msg: 'A valid date must be provided' }, context);
-      }
-
-      date = event.queryStringParameters.date;
-      park = await getPark(event.queryStringParameters.park);
+      };
+      let date = event.queryStringParameters.date;
+      let park = await getPark(event.queryStringParameters.park);
       if (park.length < 1) {
         return sendResponse(404, { msg: 'Park not found' }, context);
       };
       facility = await getFacility(event.queryStringParameters.park, event.queryStringParameters.facility);
       if (facility.length < 1) {
         return sendResponse(404, { msg: 'Facility not found' }, context);
-      }
+      };
 
       // Don't return any dates to the public in the past or beyond the lookahead date.
       const lookAheadDays = facility.bookingDaysAhead || DEFAULT_BOOKING_DAYS_AHEAD;
@@ -51,20 +62,8 @@ exports.handler = async (event, context) => {
         return sendResponse(400, { msg: `Date must be at most ${lookAheadDays} day(s) in the future` }, context);
       } else if (date < todayDateTime.toISODate()) {
         return sendResponse(400, { msg: 'Date cannot be in the past' }, context);
-      }
-    }
-
-    // if authorized but not sysadmin, we need to check park roles.
-    if (permissionObject.isAuthenticated && !permissionObject.isAdmin) {
-      logger.debug('**AUTHORIZED, NOT SYSADMIN**');
-      park = await getPark(event.queryStringParameters.park);
-      logger.debug('Roles:', permissionObject.roles);
-      park = await roleFilter(park, permissionObject.roles);
-      // if user does not have correct park role, then they are not authorized. 
-      if (park.length < 1) {
-        return sendResponse(403, { msg: 'Unauthorized' }, context);
-      }
-    }
+      };
+    };
 
     // build the reservation query object
     if (event.queryStringParameters.park && event.queryStringParameters.facility) {
@@ -72,103 +71,93 @@ exports.handler = async (event, context) => {
       let queryObj = {
         TableName: TABLE_NAME,
         ConsistentRead: true,
-        ExpressionAttributeNames: {
-          '#pk': 'pk'
-        },
         ExpressionAttributeValues: {
           ':pk': { S: `reservations::${event.queryStringParameters.park}::${event.queryStringParameters.facility}` }
         },
-        KeyConditionExpression: '#pk = :pk'
+        KeyConditionExpression: 'pk = :pk'
       };
 
       // if we are searching for a specific date
       if (event.queryStringParameters.date) {
-        queryObj.ExpressionAttributeNames['#sk'] = 'sk';
         queryObj.ExpressionAttributeValues[':date'] = { S: event.queryStringParameters.date };
-        queryObj.KeyConditionExpression += ' AND #sk = :date';
-      }
+        queryObj.KeyConditionExpression += ' AND sk = :date';
+      };
 
       let reservations = await runQuery(queryObj);
-
       // format/filter results based on permissions
+      // Sysadmin receives all
+      // Auth'd only receives what roles they have, otherwise they receive nothing. 
+      // Unauth/public receives a heavily filtered payload
       if (!permissionObject.isAuthenticated) {
-        // public receives a heavily filtered payload
-        reservations = formatPublicResults(reservations[0], facility[0], date);
-      } else if (permissionObject.isAdmin) {
-        // Return everything to sysadmins
-        logger.debug('**SYSADMIN**');
-      }
+        reservations = formatPublicResults(reservations[0], facility[0], event.queryStringParameters.date);
+      };
 
       logger.debug('GET reservations:', reservations)
       return sendResponse(200, reservations);
-    }
+    };
   } catch (err) {
     logger.error('ERROR:', err);
-    return sendResponse(400, {msg: err}, context);
-  }
+    return sendResponse(400, { msg: err }, context);
+  };
 };
 
-async function getPark(park) {
+async function getPark(park, authenticated = false) {
   try {
     let queryObj = {
       TableName: TABLE_NAME,
       ConsistentRead: true,
-      ExpressionAttributeNames: {
-        '#pk': 'pk',
-        '#sk': 'sk',
-        '#visible': 'visible'
-      },
       ExpressionAttributeValues: {
         ':pk': { S: 'park' },
-        ':sk': { S: park },
-        ':visible': { BOOL: true }
+        ':sk': { S: park }
       },
-      KeyConditionExpression: '#pk = :pk AND #sk = :sk',
-      FilterExpression: '#visible = :visible'
-    }
+      KeyConditionExpression: 'pk = :pk AND sk = :sk',
+    };
+
+    if (!authenticated) {
+      queryObj.ExpressionAttributeValues[':visible'] = { BOOL: true };
+      queryObj.FilterExpression = 'visible = :visible';
+    };
 
     res = await runQuery(queryObj);
     if (!res) {
       throw 'Park was not found.';
-    }
+    };
     logger.debug('Public reservations - GET park:', res);
     return res;
   } catch (err) {
     logger.error('ERROR:', err);
     return {};
-  }
-}
+  };
+};
 
-async function getFacility(park, facility) {
+async function getFacility(park, facility, authenticated = false) {
   try {
     let queryObj = {
       TableName: TABLE_NAME,
       ConsistentRead: true,
-      ExpressionAttributeNames: {
-        '#pk': 'pk',
-        '#sk': 'sk',
-        '#visible': 'visible'
-      },
       ExpressionAttributeValues: {
         ':pk': { S: `facility::${park}` },
-        ':sk': { S: facility },
-        ':visible': { BOOL: true }
+        ':sk': { S: facility }
       },
-      KeyConditionExpression: '#pk = :pk AND #sk = :sk',
-      FilterExpression: '#visible = :visible'
+      KeyConditionExpression: 'pk = :pk AND sk = :sk',
+    };
+
+    if (!authenticated) {
+      queryObj.ExpressionAttributeValues[':visible'] = { BOOL: true };
+      queryObj.FilterExpression = 'visible = :visible';
     };
 
     res = await runQuery(queryObj);
     if (!res) {
       throw 'Facility was not found.';
-    }
+    };
     logger.debug('Public reservations - GET facility:', res);
     return res;
   } catch (err) {
     logger.error('ERROR:', err);
     return {};
-  }
-}
+  };
+};
 
 // Remove fields from public results.
 function formatPublicResults(reservations, facility, date) {
@@ -176,20 +165,20 @@ function formatPublicResults(reservations, facility, date) {
   // Sanity check - if there is no date, send back empty object - public must provide date.
   if (!date) {
     return publicObj;
-  }
+  };
   // If there is a facility but no reservation object, we can assume there are no reservations yet for the date.
   // We can prepopulate the results with a template of the facility's capacities.
   if (facility) {
     for (const key of Object.keys(facility.bookingTimes)) {
       publicObj[key] = 'High';
-    }
-  }
+    };
+  };
   // If we have a reservation object, overwrite the facility capacity template with reservation object values.
   if (reservations) {
     for (const [key, value] of Object.entries(reservations.capacities)) {
       publicObj[key] = getCapacityLevel(value.baseCapacity, value.availablePasses, value.capacityModifier);
-    }
-  }
+    };
+  };
   return publicObj;
 };
 
@@ -206,5 +195,5 @@ function getCapacityLevel(base, available, modifier) {
     return 'Low';
   } else {
     return 'Full';
-  }
+  };
 };

--- a/serverless.yml
+++ b/serverless.yml
@@ -118,7 +118,7 @@ functions:
     events:
       - http:
           method: GET
-          path: /reservations
+          path: /reservation
           cors: true
 
   ###########

--- a/serverless.yml
+++ b/serverless.yml
@@ -111,6 +111,17 @@ functions:
           cors: true
 
   ###########
+  # Reservations
+  ###########
+  readReservation:
+    handler: lambda/readReservation/index.handler
+    events:
+      - http:
+          method: GET
+          path: /reservations
+          cors: true
+
+  ###########
   # Pass
   ###########
   readPass:

--- a/terraform/src/main.tf
+++ b/terraform/src/main.tf
@@ -170,7 +170,8 @@ resource "aws_api_gateway_deployment" "apideploy" {
     aws_api_gateway_integration.putFacilityIntegration,
     aws_api_gateway_integration.generateCaptchaIntegration,
     aws_api_gateway_integration.captchaVerifyIntegration,
-    aws_api_gateway_integration.captchaAudioIntegration
+    aws_api_gateway_integration.captchaAudioIntegration,
+    aws_api_gateway_integration.readReservationIntegration
   ]
 
   rest_api_id = aws_api_gateway_rest_api.apiLambda.id

--- a/terraform/src/reservations.tf
+++ b/terraform/src/reservations.tf
@@ -1,0 +1,129 @@
+// Deploys the lambda via the zip above
+resource "aws_lambda_function" "readReservationLambda" {
+  function_name = "readReservation"
+
+  filename         = "artifacts/readReservation.zip"
+  source_code_hash = filebase64sha256("artifacts/readReservation.zip")
+
+  handler = "lambda/readReservation/index.handler"
+  runtime = "nodejs14.x"
+  publish = "true"
+
+  memory_size = 768
+  timeout = 10
+
+  environment {
+    variables = {
+      TABLE_NAME   = data.aws_ssm_parameter.db_name.value,
+      SSO_ISSUER   = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_JWKSURI  = data.aws_ssm_parameter.sso_jwksuri.value,
+    }
+  }
+
+  role = aws_iam_role.readRole.arn
+}
+
+resource "aws_lambda_alias" "readReservationLambdaLatest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.readReservationLambda.function_name
+  function_version = aws_lambda_function.readReservationLambda.version
+}
+
+resource "null_resource" "alias_provisioned_concurrency_transition_delay_read_reservation_lambda" {
+  depends_on = [aws_lambda_alias.readReservationLambdaLatest]
+  provisioner "local-exec" {
+   command = "sleep 240"
+  }
+  triggers = {
+     function_version = "${aws_lambda_function.readReservationLambda.version}"
+  }
+}
+
+resource "aws_lambda_provisioned_concurrency_config" "readReservationLambda" {
+  depends_on = [null_resource.alias_provisioned_concurrency_transition_delay_read_reservation_lambda]
+  function_name                     = aws_lambda_alias.readReservationLambdaLatest.function_name
+  provisioned_concurrent_executions = 2
+  qualifier                         = aws_lambda_alias.readReservationLambdaLatest.name
+}
+
+resource "aws_api_gateway_resource" "reservationResource" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  parent_id   = aws_api_gateway_rest_api.apiLambda.root_resource_id
+  path_part   = "reservations"
+}
+
+// Defines the HTTP GET /reservations API
+resource "aws_api_gateway_method" "readReservationMethod" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = aws_api_gateway_resource.reservationResource.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_lambda_permission" "readReservationPermission" {
+  statement_id  = "AllowParksDayUseReservationAPIInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.readReservationLambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/GET/reservations"
+}
+
+// Integrates the APIG to Lambda via POST method
+resource "aws_api_gateway_integration" "readReservationIntegration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.reservationResource.id
+  http_method = aws_api_gateway_method.readReservationMethod.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.readReservationLambda.invoke_arn
+}
+
+//CORS
+resource "aws_api_gateway_method" "reservation_options_method" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = aws_api_gateway_resource.reservationResource.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method_response" "reservation_options_200" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.reservationResource.id
+  http_method = aws_api_gateway_method.reservation_options_method.http_method
+  status_code = "200"
+  response_models = {
+    "application/json" = "Empty"
+  }
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true,
+    "method.response.header.Access-Control-Allow-Methods" = true,
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+  depends_on = [aws_api_gateway_method.reservation_options_method]
+}
+
+resource "aws_api_gateway_integration" "reservations_options_integration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.reservationResource.id
+  http_method = aws_api_gateway_method.reservation_options_method.http_method
+  type        = "MOCK"
+  request_templates = {
+    "application/json" : "{\"statusCode\": 200}"
+  }
+  depends_on = [aws_api_gateway_method.reservation_options_method]
+}
+
+resource "aws_api_gateway_integration_response" "reservation_options_integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.reservationResource.id
+  http_method = aws_api_gateway_method.reservation_options_method.http_method
+
+  status_code = aws_api_gateway_method_response.reservation_options_200.status_code
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+    "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS'",
+    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+  }
+  depends_on = [aws_api_gateway_method_response.reservation_options_200]
+}

--- a/terraform/src/reservations.tf
+++ b/terraform/src/reservations.tf
@@ -49,10 +49,10 @@ resource "aws_lambda_provisioned_concurrency_config" "readReservationLambda" {
 resource "aws_api_gateway_resource" "reservationResource" {
   rest_api_id = aws_api_gateway_rest_api.apiLambda.id
   parent_id   = aws_api_gateway_rest_api.apiLambda.root_resource_id
-  path_part   = "reservations"
+  path_part   = "reservation"
 }
 
-// Defines the HTTP GET /reservations API
+// Defines the HTTP GET /reservation API
 resource "aws_api_gateway_method" "readReservationMethod" {
   rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
   resource_id   = aws_api_gateway_resource.reservationResource.id
@@ -65,7 +65,7 @@ resource "aws_lambda_permission" "readReservationPermission" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.readReservationLambda.function_name
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/GET/reservations"
+  source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/GET/reservation"
 }
 
 // Integrates the APIG to Lambda via POST method

--- a/terraform/src/warmUp.tf
+++ b/terraform/src/warmUp.tf
@@ -51,6 +51,11 @@ resource "aws_cloudwatch_event_target" "warm_up_every_morning" {
           "concurrency": "10"
         },
         {
+          "funcName": "readReservation",
+          "funcVersion": "latest",
+          "concurrency": "10"
+        },
+        {
           "funcName": "generateCaptcha",
           "funcVersion": "latest",
           "concurrency": "5"


### PR DESCRIPTION
### Jira Ticket:

BRS-719

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-719

### Description:

This change adds a `readReservation` endpoint at GET api/reservations. The call must be accompanied by the following query parameters:

- park
- facility
- date (optional)

Example query:

`.../api/reservations?park=Garibaldi Provincial Park&facility=Cheakamus - Parking&date=2022-07-11`

If no date is provided, the user will be returned all reservation objects for that park/facility combination. If a date is provided, the result will be narrowed down to one reservation object for that specified date.

The returned payload depends on the authentication level of the user.

- Sysadmins get everything.
- Admins with specific park roles can only receive reservation objects for their specifically assigned parks, otherwise nothing is returned.
- Public/unauthorized users MUST provide a date and get a heavily modified reservation object that only contains the availability level for each pass type in that facility on that date, for example:

```
{
   "AM": "Full",
   "PM": "Moderate"
}
```

Public/unauthorized users can only query reservations on dates between 'today' and the maximum booking look ahead date (3 days in the future, by default). Authorized users can query reservation objects on any date, future or past.

If a queried date does not contain a reservation object (i.e, no reservations have yet been made):

- Authorized users receive nothing
- Public users receive their simplified reservation object with all pass type availabilities set to 'High'.

This change relies on reading reservation objects created using changes included in #127.

