### PR TITLE
BRS-719 adding readReservation lambda

### DIFF
--- a/lambda/readReservation/index.js
+++ b/lambda/readReservation/index.js
@@ -1,0 +1,156 @@
+const { runQuery, TABLE_NAME, DEFAULT_BOOKING_DAYS_AHEAD, TIMEZONE, getPark, getFacility } = require('../dynamoUtil');
+const { sendResponse } = require('../responseUtil');
+const { decodeJWT, resolvePermissions, roleFilter } = require('../permissionUtil');
+const { logger } = require('../logger');
+const { DateTime } = require('luxon');
+
+// TODO: provide these as vars in Parameter Store
+const LOW_CAPACITY_THRESHOLD = process.env.LOW_CAPACITY_THRESHOLD || 0.25;
+const MODERATE_CAPACITY_THRESHOLD = process.env.MODERATE_CAPACITY_THRESHOLD || 0.75;
+
+exports.handler = async (event, context) => {
+  logger.debug('Read Reservation', event);
+  logger.debug('event.queryStringParameters', event.queryStringParameters);
+
+  try {
+    if (!event.queryStringParameters || !event.queryStringParameters.park || !event.queryStringParameters.facility) {
+      return sendResponse(400, { msg: 'Invalid Request' }, context);
+    };
+
+    const park = event.queryStringParameters.park;
+    const facility = event.queryStringParameters.facility;
+    const date = event.queryStringParameters.date || '';
+    let facilityObj = {};
+    let bookingWindow = [date];
+
+    const token = await decodeJWT(event);
+    const permissionObject = resolvePermissions(token);
+
+    if (permissionObject.isAuthenticated) {
+      // Auth'd users must provide a date.
+      if (!date) {
+        return sendResponse(400, { msg: 'Please provide a date.' });
+      };
+      if (permissionObject.isAdmin) {
+        logger.debug('**SYSADMIN**');
+      } else {
+        logger.debug('**AUTHENTICATED, NOT SYSADMIN**');
+        let parkObj = await getPark(park.sk, true);
+
+        // Check roles. 
+        logger.debug('Roles:', permissionObject.roles);
+        parkObj = await roleFilter(park, permissionObject.roles);
+
+        // If user does not have correct park role, then they are not authorized. 
+        if (park.length < 1) {
+          return sendResponse(403, { msg: 'Unauthorized' }, context);
+        };
+      };
+    } else {
+      // If public, we have to check park/facility visibility first.
+      logger.debug('**NOT AUTHENTICATED, PUBLIC**');
+      let parkObj = await getPark(park);
+      if (!parkObj) {
+        return sendResponse(404, { msg: 'Park not found' }, context);
+      };
+      facilityObj = await getFacility(park, facility);
+      if (!facilityObj) {
+        return sendResponse(404, { msg: 'Facility not found' }, context);
+      };
+       
+      const window = getBookingWindow(facilityObj);
+
+      if (!date) {
+        bookingWindow = window;
+      } else if (!window.includes(date)) {
+        return sendResponse(400, {msg: `Provided date must be between today's date and ${facilityObj.bookingDaysAhead} days in the future`});
+      };
+    };
+
+    // Build the reservation query object.
+    logger.debug('Grab reservations for facility:', facility);
+    let queryObj = {
+      TableName: TABLE_NAME,
+      ConsistentRead: true,
+      ExpressionAttributeValues: {
+        ':pk': { S: `reservations::${park}::${facility}` }
+      },
+      KeyConditionExpression: 'pk = :pk'
+    };
+
+    if (date) {
+      // We are searching for a specific date.
+      queryObj.ExpressionAttributeValues[':date'] = { S: date };
+      queryObj.KeyConditionExpression += ' AND sk = :date';
+    } else {
+      // We must be public, and we want to pull the whole date window.
+      queryObj.ExpressionAttributeValues[':startDate'] = { S: bookingWindow[0] };
+      queryObj.ExpressionAttributeValues[':endDate'] = { S: bookingWindow[bookingWindow.length - 1] };
+      queryObj.KeyConditionExpression += ' AND sk BETWEEN :startDate AND :endDate';
+    };
+
+    let reservations = await runQuery(queryObj);
+
+    // Format/filter public results.
+    if (!permissionObject.isAuthenticated) {
+      reservations = formatPublicResults(reservations, facilityObj, bookingWindow);
+    };
+
+    logger.debug('GET reservations:', reservations)
+    return sendResponse(200, reservations);
+  } catch (err) {
+    logger.error('ERROR:', err);
+    return sendResponse(400, { msg: err }, context);
+  };
+};
+
+// Filter fields from public results.
+function formatPublicResults(reservations, facility, bookingWindow) {
+  let publicObj = buildPublicTemplate(facility, bookingWindow);
+  for (let reservation of reservations) {
+    for (const [key, value] of Object.entries(reservation.capacities)) {
+      publicObj[reservation.sk][key] = getCapacityLevel(value.baseCapacity, value.availablePasses, value.capacityModifier);
+    };
+  };
+  return publicObj;
+};
+
+// Build empty public template to be populated with real reservation data if it exists.
+function buildPublicTemplate(facility, bookingWindow) {
+  let template = {};
+  for (let date of bookingWindow) {
+    let dateEntry = {};
+    for (const key of Object.keys(facility.bookingTimes)) {
+      dateEntry[key] = 'High';
+    };
+    template[date] = dateEntry;
+  };
+  return template;
+};
+
+// Get array of shortDates between today and max future look ahead date.
+function getBookingWindow(facilityObj) {
+  const lookAheadDays = facilityObj.bookingDaysAhead || DEFAULT_BOOKING_DAYS_AHEAD;
+  const today = DateTime.now().setZone(TIMEZONE);
+  let dates = [];
+  for (let i = 0; i <= lookAheadDays; i++) {
+    dates.push(today.plus({ days: i }).toISODate());
+  };
+  return dates;
+};
+
+// Get capacity level (high, med, low, none) of a facility.
+function getCapacityLevel(base, available, modifier) {
+  const capacity = base + modifier;
+  const booked = capacity - available;
+  const percentage = booked / capacity;
+  if (percentage < LOW_CAPACITY_THRESHOLD) {
+    return 'High';
+  } else if (percentage < MODERATE_CAPACITY_THRESHOLD) {
+    return 'Moderate';
+  } else if (percentage < 1) {
+    return 'Low';
+  } else {
+    return 'Full';
+  };
+};

--- a/serverless.yml
+++ b/serverless.yml
@@ -111,6 +111,17 @@ functions:
           cors: true
 
   ###########
+  # Reservations
+  ###########
+  readReservation:
+    handler: lambda/readReservation/index.handler
+    events:
+      - http:
+          method: GET
+          path: /reservation
+          cors: true
+
+  ###########
   # Pass
   ###########
   readPass:

--- a/terraform/src/main.tf
+++ b/terraform/src/main.tf
@@ -170,7 +170,8 @@ resource "aws_api_gateway_deployment" "apideploy" {
     aws_api_gateway_integration.putFacilityIntegration,
     aws_api_gateway_integration.generateCaptchaIntegration,
     aws_api_gateway_integration.captchaVerifyIntegration,
-    aws_api_gateway_integration.captchaAudioIntegration
+    aws_api_gateway_integration.captchaAudioIntegration,
+    aws_api_gateway_integration.readReservationIntegration
   ]
 
   rest_api_id = aws_api_gateway_rest_api.apiLambda.id

--- a/terraform/src/reservations.tf
+++ b/terraform/src/reservations.tf
@@ -1,0 +1,129 @@
+// Deploys the lambda via the zip above
+resource "aws_lambda_function" "readReservationLambda" {
+  function_name = "readReservation"
+
+  filename         = "artifacts/readReservation.zip"
+  source_code_hash = filebase64sha256("artifacts/readReservation.zip")
+
+  handler = "lambda/readReservation/index.handler"
+  runtime = "nodejs14.x"
+  publish = "true"
+
+  memory_size = 768
+  timeout = 10
+
+  environment {
+    variables = {
+      TABLE_NAME   = data.aws_ssm_parameter.db_name.value,
+      SSO_ISSUER   = data.aws_ssm_parameter.sso_issuer.value,
+      SSO_JWKSURI  = data.aws_ssm_parameter.sso_jwksuri.value,
+    }
+  }
+
+  role = aws_iam_role.readRole.arn
+}
+
+resource "aws_lambda_alias" "readReservationLambdaLatest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.readReservationLambda.function_name
+  function_version = aws_lambda_function.readReservationLambda.version
+}
+
+resource "null_resource" "alias_provisioned_concurrency_transition_delay_read_reservation_lambda" {
+  depends_on = [aws_lambda_alias.readReservationLambdaLatest]
+  provisioner "local-exec" {
+   command = "sleep 240"
+  }
+  triggers = {
+     function_version = "${aws_lambda_function.readReservationLambda.version}"
+  }
+}
+
+resource "aws_lambda_provisioned_concurrency_config" "readReservationLambda" {
+  depends_on = [null_resource.alias_provisioned_concurrency_transition_delay_read_reservation_lambda]
+  function_name                     = aws_lambda_alias.readReservationLambdaLatest.function_name
+  provisioned_concurrent_executions = 2
+  qualifier                         = aws_lambda_alias.readReservationLambdaLatest.name
+}
+
+resource "aws_api_gateway_resource" "reservationResource" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  parent_id   = aws_api_gateway_rest_api.apiLambda.root_resource_id
+  path_part   = "reservation"
+}
+
+// Defines the HTTP GET /reservation API
+resource "aws_api_gateway_method" "readReservationMethod" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = aws_api_gateway_resource.reservationResource.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_lambda_permission" "readReservationPermission" {
+  statement_id  = "AllowParksDayUseReservationAPIInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.readReservationLambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/GET/reservation"
+}
+
+// Integrates the APIG to Lambda via POST method
+resource "aws_api_gateway_integration" "readReservationIntegration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.reservationResource.id
+  http_method = aws_api_gateway_method.readReservationMethod.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.readReservationLambda.invoke_arn
+}
+
+//CORS
+resource "aws_api_gateway_method" "reservation_options_method" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = aws_api_gateway_resource.reservationResource.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method_response" "reservation_options_200" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.reservationResource.id
+  http_method = aws_api_gateway_method.reservation_options_method.http_method
+  status_code = "200"
+  response_models = {
+    "application/json" = "Empty"
+  }
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true,
+    "method.response.header.Access-Control-Allow-Methods" = true,
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+  depends_on = [aws_api_gateway_method.reservation_options_method]
+}
+
+resource "aws_api_gateway_integration" "reservations_options_integration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.reservationResource.id
+  http_method = aws_api_gateway_method.reservation_options_method.http_method
+  type        = "MOCK"
+  request_templates = {
+    "application/json" : "{\"statusCode\": 200}"
+  }
+  depends_on = [aws_api_gateway_method.reservation_options_method]
+}
+
+resource "aws_api_gateway_integration_response" "reservation_options_integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.reservationResource.id
+  http_method = aws_api_gateway_method.reservation_options_method.http_method
+
+  status_code = aws_api_gateway_method_response.reservation_options_200.status_code
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+    "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS'",
+    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+  }
+  depends_on = [aws_api_gateway_method_response.reservation_options_200]
+}

--- a/terraform/src/warmUp.tf
+++ b/terraform/src/warmUp.tf
@@ -51,6 +51,11 @@ resource "aws_cloudwatch_event_target" "warm_up_every_morning" {
           "concurrency": "10"
         },
         {
+          "funcName": "readReservation",
+          "funcVersion": "latest",
+          "concurrency": "10"
+        },
+        {
           "funcName": "generateCaptcha",
           "funcVersion": "latest",
           "concurrency": "5"


### PR DESCRIPTION
### Jira Ticket:

BRS-719

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-719

### Description:

This change adds a `readReservation` endpoint at GET api/reservations. The call must be accompanied by the following query parameters:

- park
- facility
- date

Example query:

`.../api/reservations?park=Garibaldi Provincial Park&facility=Cheakamus - Parking&date=2022-07-11`

The returned payload depends on the authentication level of the user.

- Sysadmins get everything.
- Admins with specific park roles can only receive reservation objects for their specifically assigned parks, otherwise nothing is returned.
- Public users can opt out of providing a date and will receive a heavily modified reservation object that only contains the availability level for each pass type in that facility. For example:

```
{
    "2022-07-20": {
        "DAY": {
            "capacity": "Moderate",
            "max": 4
        }
    },
    "2022-07-21": {
        "DAY": {
            "capacity": "High",
            "max": 4
        }
    },
    "2022-07-22": {
        "DAY": {
            "capacity": "Low",
            "max": 2
        }
    }
}
```

Authorized users must provide a date.

Public/unauthorized users can only query reservations on dates between 'today' and the maximum booking look ahead date (3 days in the future, by default). Authorized users can query reservation objects on any date, future or past.

If a queried date does not contain a reservation object (i.e, no reservations have yet been made):

- Authorized users receive nothing
- Public users receive their simplified reservation object with all pass type availabilities set to 'High'.

This change relies on reading reservation objects created using changes included in https://github.com/bcgov/parks-reso-api/pull/127.

This change is remade from #130.
