### PR TITLE
BRS-729: Error searching by reservation number

### DIFF
--- a/lambda/readPass/index.js
+++ b/lambda/readPass/index.js
@@ -84,8 +84,15 @@ exports.handler = async (event, context) => {
       }
       // Filter reservation number
       if (event.queryStringParameters.reservationNumber) {
-        queryObj.ExpressionAttributeValues[':sk'] = { S: event.queryStringParameters.reservationNumber };
-        queryObj.KeyConditionExpression += expressionBuilder('AND', queryObj.KeyConditionExpression, 'sk =:sk');
+        queryObj.ExpressionAttributeNames['#registrationNumber'] = 'registrationNumber';
+        queryObj.ExpressionAttributeValues[':registrationNumber'] = AWS.DynamoDB.Converter.input(
+          event.queryStringParameters.reservationNumber
+        );
+        queryObj.FilterExpression += expressionBuilder(
+          'AND',
+          queryObj.FilterExpression,
+          '#registrationNumber =:registrationNumber'
+        );
       }
       // Filter first/last
       if (event.queryStringParameters.firstName) {

--- a/lambda/readPass/index.js
+++ b/lambda/readPass/index.js
@@ -85,7 +85,7 @@ exports.handler = async (event, context) => {
       // Filter reservation number
       if (event.queryStringParameters.reservationNumber) {
         queryObj.ExpressionAttributeValues[':registrationNumber'] = AWS.DynamoDB.Converter.input(
-          // BRS-728 will address inconsistent mapping of registrationNumber to reservationNumber
+          // BRS-748 will address inconsistent mapping of registrationNumber to reservationNumber
           event.queryStringParameters.reservationNumber
         );
         queryObj.FilterExpression += expressionBuilder(

--- a/lambda/readPass/index.js
+++ b/lambda/readPass/index.js
@@ -84,47 +84,43 @@ exports.handler = async (event, context) => {
       }
       // Filter reservation number
       if (event.queryStringParameters.reservationNumber) {
-        queryObj.ExpressionAttributeNames['#registrationNumber'] = 'registrationNumber';
-        queryObj.ExpressionAttributeValues[':registrationNumber'] = AWS.DynamoDB.Converter.input(
+        queryObj.ExpressionAttributeValues[':reservationNumber'] = AWS.DynamoDB.Converter.input(
           event.queryStringParameters.reservationNumber
         );
         queryObj.FilterExpression += expressionBuilder(
           'AND',
           queryObj.FilterExpression,
-          '#registrationNumber =:registrationNumber'
+          'registrationNumber =:reservationNumber'
         );
       }
       // Filter first/last
       if (event.queryStringParameters.firstName) {
         queryObj = checkAddExpressionAttributeNames(queryObj);
-        queryObj.ExpressionAttributeNames['#searchFirstName'] = 'searchFirstName';
         queryObj.ExpressionAttributeValues[':searchFirstName'] = AWS.DynamoDB.Converter.input(
           event.queryStringParameters.firstName.toLowerCase()
         );
         queryObj.FilterExpression += expressionBuilder(
           'AND',
           queryObj.FilterExpression,
-          '#searchFirstName =:searchFirstName'
+          'searchFirstName =:searchFirstName'
         );
       }
       if (event.queryStringParameters.lastName) {
         queryObj = checkAddExpressionAttributeNames(queryObj);
-        queryObj.ExpressionAttributeNames['#searchLastName'] = 'searchLastName';
         queryObj.ExpressionAttributeValues[':searchLastName'] = AWS.DynamoDB.Converter.input(
           event.queryStringParameters.lastName.toLowerCase()
         );
         queryObj.FilterExpression += expressionBuilder(
           'AND',
           queryObj.FilterExpression,
-          '#searchLastName =:searchLastName'
+          'searchLastName =:searchLastName'
         );
       }
       // Filter email
       if (event.queryStringParameters.email) {
         queryObj = checkAddExpressionAttributeNames(queryObj);
-        queryObj.ExpressionAttributeNames['#email'] = 'email';
         queryObj.ExpressionAttributeValues[':email'] = AWS.DynamoDB.Converter.input(event.queryStringParameters.email);
-        queryObj.FilterExpression += expressionBuilder('AND', queryObj.FilterExpression, '#email =:email');
+        queryObj.FilterExpression += expressionBuilder('AND', queryObj.FilterExpression, 'email =:email');
       }
       queryObj = paginationHandler(queryObj, event);
 

--- a/lambda/readPass/index.js
+++ b/lambda/readPass/index.js
@@ -84,13 +84,14 @@ exports.handler = async (event, context) => {
       }
       // Filter reservation number
       if (event.queryStringParameters.reservationNumber) {
-        queryObj.ExpressionAttributeValues[':reservationNumber'] = AWS.DynamoDB.Converter.input(
+        queryObj.ExpressionAttributeValues[':registrationNumber'] = AWS.DynamoDB.Converter.input(
+          // BRS-728 will address inconsistent mapping of registrationNumber to reservationNumber
           event.queryStringParameters.reservationNumber
         );
         queryObj.FilterExpression += expressionBuilder(
           'AND',
           queryObj.FilterExpression,
-          'registrationNumber =:reservationNumber'
+          'registrationNumber =:registrationNumber'
         );
       }
       // Filter first/last


### PR DESCRIPTION
### Jira Ticket:

BRS-729

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-729

### Description:

Based on my testing, searching by reservation number never worked (it didn’t work sometimes as stated in the ticket title)  

The actual error was **“Conditions can be of length 1 or 2 only”**

This query was causing the error:

```
{
   "TableName":"parksreso",
   "ExpressionAttributeValues":{
      ":shortPassDate":{
         "S":"2022-07-21"
      },
      ":facilityName":{
         "S":"Test"
      },
      ":passType":{
         "S":"DAY"
      },
      ":sk":{
         "S":"055291844"
      }
   },
   "IndexName":"shortPassDate-index",
   "KeyConditionExpression":"shortPassDate =:shortPassDate AND facilityName =:facilityName AND sk =:sk",
   "FilterExpression":"#theType =:passType",
   "ExpressionAttributeNames":{
      "#theType":"type"
   }
}
```

I moved the ` AND sk =:sk` check from `KeyConditionExpression` to `FilterExpression` to and changed it to check for ` AND #registrationNumber =:registrationNumber` instead.  This matches the pattern being used by firstName, lastName, email, etc.

```
{
   "TableName":"parksreso",
   "ExpressionAttributeValues":{
      ":shortPassDate":{
         "S":"2022-07-21"
      },
      ":facilityName":{
         "S":"Test"
      },
      ":passType":{
         "S":"DAY"
      },
      ":registrationNumber":{
         "S":"055291844"
      }
   },
   "IndexName":"shortPassDate-index",
   "KeyConditionExpression":"shortPassDate =:shortPassDate AND facilityName =:facilityName",
   "FilterExpression":"#theType =:passType AND #registrationNumber =:registrationNumber",
   "ExpressionAttributeNames":{
      "#theType":"type",
      "#registrationNumber":"registrationNumber"
   }
}
```