### PR TITLE
NOBUG: Enable debug logs for cloudwatch alarms

### DIFF
--- a/terraform/src/cloudwatchAlarms.tf
+++ b/terraform/src/cloudwatchAlarms.tf
@@ -16,6 +16,7 @@ resource "aws_lambda_function" "cloudwatch_alarm" {
       AWS_ACCOUNT_LIST = data.aws_ssm_parameter.aws_account_list.value,
       ROCKETCHAT_URL = data.aws_ssm_parameter.rocketchat_url.value,
       ROCKETCHAT_BEARER_TOKEN = data.aws_ssm_parameter.rocketchat_bearer_token.value,
+      LOG_LEVEL = 'debug'
     }
   }
 }


### PR DESCRIPTION
### Description:

This enables more verbose logs in the cloudwatch alarm lambda.