### PR TITLE
BRS-595 allowing sysadmins to bulk book passes

### DIFF
--- a/__tests__/writePass.test.js
+++ b/__tests__/writePass.test.js
@@ -44,11 +44,14 @@ describe('Pass Fails', () => {
 
   test('Handler - 400 Bad Request - Missing JWT', async () => {
     const event = {
-      body: JSON.stringify({
-        parkName: '',
+      headers: {
+        Authorization: 'None'
+      },
+       body: JSON.stringify({
+        parkName: 'Test Park 1',
         firstName: '',
         lastName: '',
-        facilityName: '',
+        facilityName: 'Parking lot A',
         email: '',
         date: '',
         type: '',
@@ -74,11 +77,14 @@ describe('Pass Fails', () => {
 
   test('Handler - 400 Bad Request - JWT Invalid', async () => {
     const event = {
+      headers: {
+        Authorization: 'None'
+      },
       body: JSON.stringify({
-        parkName: '',
+        parkName: 'Test Park 1',
         firstName: '',
         lastName: '',
-        facilityName: '',
+        facilityName: 'Parking lot A',
         email: '',
         date: '',
         type: '',
@@ -104,6 +110,9 @@ describe('Pass Fails', () => {
 
   test('Handler - 400 Bad Request - Trail pass limit maximum', async () => {
     const event = {
+      headers: {
+        Authorization: 'None'
+      },
       body: JSON.stringify({
         parkName: 'Test Park 1',
         firstName: '',
@@ -131,6 +140,9 @@ describe('Pass Fails', () => {
 
   test('Handler - 400 Bad Request - Invalid Date', async () => {
     const event = {
+      headers: {
+        Authorization: 'None'
+      },
       body: JSON.stringify({
         parkName: '',
         firstName: '',
@@ -161,11 +173,14 @@ describe('Pass Fails', () => {
 
   test('Handler - 400 Bad Request - Booking date in the past', async () => {
     const event = {
+      headers: {
+        Authorization: 'None'
+      },
       body: JSON.stringify({
-        parkName: '',
+        parkName: 'Test Park 1',
         firstName: '',
         lastName: '',
-        facilityName: '',
+        facilityName: 'Parking lot A',
         email: '',
         date: '1970-01-01T00:00:00.758Z',
         type: '',
@@ -191,6 +206,9 @@ describe('Pass Fails', () => {
 
   test('Handler - 400 Bad Request - One or more params are invalid.', async () => {
     const event = {
+      headers: {
+        Authorization: 'None'
+      },
       body: JSON.stringify({
         parkName: '',
         firstName: '',
@@ -231,6 +249,9 @@ describe('Pass Successes', () => {
 
   test('Handler - 200 Email Failed to Send, but pass has been created for a Trail.', async () => {
     const event = {
+      headers: {
+        Authorization: 'None'
+      },
       body: JSON.stringify({
         parkName: 'Test Park 1',
         firstName: 'Jest',
@@ -266,6 +287,9 @@ describe('Pass Successes', () => {
 
   test('Handler - 200 Email Failed to Send, but pass has been created for a Parking Pass.', async () => {
     const event = {
+      headers: {
+        Authorization: 'None'
+      },
       body: JSON.stringify({
         parkName: 'Test Park 1',
         firstName: 'Jest',


### PR DESCRIPTION
### Jira Ticket:

BRS-595

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-595

### Description:

This change alters the `writePass` endpoint to give sysadmins special privileges when creating passes. An authorized sysadmin can now book up to the available facility capacity, and can bypass certain checks.

Sysadmins do not need to provide a valid captcha JWT.

Sysadmins can book above the maximum number of guests allowed on a single public pass.

Sysadmins can book any date in the future.

Sysadmins cannot book a date in the past.

Sysadmins cannot overbook a facility.

Below is an example of the simplified payload a sysadmin can send to the `writePass` endpoint.

```
POST .../api/pass

{
    "numberOfGuests": 8,
    "lastName": "Bulk",
    "facilityName": "Cheakamus",
    "email": "bulkbooking@recipient.com",
    "firstName": "Booking",
    "date": "2023-07-30T11:00:00.003-07:00",
    "type": "PM",
    "parkName": "Garibaldi Provincial Park"
}
```