### PR TITLE
BRS-761-2 allow readReservation to create time slot if it doesnt exist

### DIFF
--- a/lambda/readReservation/index.js
+++ b/lambda/readReservation/index.js
@@ -111,8 +111,11 @@ function formatPublicResults(reservations, facility, bookingWindow) {
   let publicObj = buildPublicTemplate(facility, bookingWindow);
   for (let reservation of reservations) {
     for (const [key, value] of Object.entries(reservation.capacities)) {
-      publicObj[reservation.sk][key].capacity = getCapacityLevel(value.baseCapacity, value.availablePasses, value.capacityModifier);
-      publicObj[reservation.sk][key].max = checkMaxPasses(facility, value.availablePasses);
+      const bookingSlot = {
+        capacity: getCapacityLevel(value.baseCapacity, value.availablePasses, value.capacityModifier),
+        max: checkMaxPasses(facility, value.availablePasses)
+      };
+      publicObj[reservation.sk][key] = bookingSlot;
     };
   };
   return publicObj;


### PR DESCRIPTION
### Jira Ticket:

BRS-761

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-761

### Description:

This change allows `readReservation` to create a booking time object if it doesn't previously exist.
