### PR TITLE
BRS-776: improving existing pass query efficiency

### DIFF
--- a/lambda/writePass/index.js
+++ b/lambda/writePass/index.js
@@ -241,19 +241,18 @@ exports.handler = async (event, context) => {
       try {
         const existingPassCheckObject = {
           TableName: TABLE_NAME,
-          KeyConditionExpression: 'pk = :pk',
+          IndexName: 'shortPassDate-index',
+          KeyConditionExpression: 'shortPassDate = :shortPassDate AND facilityName = :facilityName',
           FilterExpression:
-            'facilityName = :facilityName AND email = :email AND #type = :type AND begins_with(#date, :date) AND (passStatus = :reserved OR passStatus = :active)',
+            'email = :email AND #type = :type AND passStatus IN (:reserved, :active)',
           ExpressionAttributeNames: {
             '#type': 'type',
-            '#date': 'date'
           },
           ExpressionAttributeValues: {
-            ':pk': { S: 'pass::' + parkName },
             ':facilityName': { S: facilityName },
             ':email': { S: email },
             ':type': { S: type },
-            ':date': { S: bookingPSTShortDate },
+            ':shortPassDate': { S: bookingPSTShortDate },
             ':reserved': { S: 'reserved' },
             ':active': { S: 'active' }
           }


### PR DESCRIPTION
### Jira Ticket:

BRS-776

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-776

### Description:

During pass creation, we run a query to see if the user has already booked under that email/bookingTime/facility combination, and refuse pass creation if they've already booked. 

In PROD, there are so many passes per facility now, that the query is timing out before completing. When it fails, the existing pass check is bypassed (because no matches were found), allowing prod users to book multiple passes under the same parameters.

This change improves the query efficiency by using the `shortPassDate-index` to drastically minimize the pool of passes to search for duplicates on. 
