### PR TITLE
BRS-774: always create resObj when editing facility

### DIFF
--- a/__tests__/writePass.test.js
+++ b/__tests__/writePass.test.js
@@ -363,7 +363,7 @@ async function databaseOperation(version, mode) {
                 max: 25
               }
             },
-            status: 'open',
+            status: {stateReason: '', state: 'open'},
             visible: true
           }
         })
@@ -387,7 +387,7 @@ async function databaseOperation(version, mode) {
                 max: 25
               }
             },
-            status: 'open',
+            status: {stateReason: '', state: 'open'},
             visible: true
           }
         })

--- a/lambda/writePass/index.js
+++ b/lambda/writePass/index.js
@@ -298,8 +298,7 @@ exports.handler = async (event, context) => {
 
       // We need to ensure that the reservations object exists.
       // Attempt to create reservations object. If it fails, so what...
-
-      await createNewReservationsObj(facilityData.bookingTimes, reservationsObjectPK, bookingPSTShortDate);
+      await createNewReservationsObj(facilityData, reservationsObjectPK, bookingPSTShortDate);
 
       // Perform a transaction where we decrement the available passes and create the pass
       // If the conditions where the related facility object has a lock, we then fail the whole transaction.

--- a/lambda/writeReservation/index.js
+++ b/lambda/writeReservation/index.js
@@ -2,26 +2,37 @@ const AWS = require('aws-sdk');
 const { dynamodb, TABLE_NAME } = require('../dynamoUtil');
 const { logger } = require('../logger');
 
+// TODO: provide these as vars in Parameter Store
+const LOW_CAPACITY_THRESHOLD = process.env.LOW_CAPACITY_THRESHOLD || 0.25;
+const MODERATE_CAPACITY_THRESHOLD = process.env.MODERATE_CAPACITY_THRESHOLD || 0.75;
+const PARKING_MAX_PER_PASS = 1;
+const TRAIL_MAX_PER_PASS = 4;
+
 exports.createNewReservationsObj = async function createNewReservationsObj(
-  facilityBookingTimes,
+  facility,
   reservationsObjectPK,
   bookingPSTShortDate
 ) {
-  const bookingTimeTypes = Object.keys(facilityBookingTimes);
+  if (!facility.bookingTimes || !facility.status.state){
+    throw 'Invalid facility object';
+  }
+
+  const bookingTimeTypes = Object.keys(facility.bookingTimes);
 
   let rawReservationsObject = {
     pk: reservationsObjectPK,
     sk: bookingPSTShortDate,
-    capacities: {}
+    capacities: {},
+    status: facility.status.state
   };
 
   // We are initing capacities
   for (let i = 0; i < bookingTimeTypes.length; i++) {
     const property = bookingTimeTypes[i];
     rawReservationsObject.capacities[property] = {
-      baseCapacity: facilityBookingTimes[property].max,
+      baseCapacity: facility.bookingTimes[property].max,
       capacityModifier: 0,
-      availablePasses: facilityBookingTimes[property].max
+      availablePasses: facility.bookingTimes[property].max
     };
   }
 
@@ -43,3 +54,66 @@ exports.createNewReservationsObj = async function createNewReservationsObj(
   }
   return res;
 };
+
+exports.formatPublicReservationObject = function formatPublicReservationObject(reservations, facility, bookingWindow) {
+  let publicObj = buildPublicTemplate(facility, bookingWindow);
+  for (let reservation of reservations) {
+    for (const [key, value] of Object.entries(reservation.capacities)) {
+      const bookingSlot = {
+        capacity: getCapacityLevel(value.baseCapacity, value.availablePasses, value.capacityModifier),
+        max: checkMaxPasses(facility, value.availablePasses)
+      };
+      publicObj[reservation.sk][key] = bookingSlot;
+    }
+  }
+  return publicObj;
+}
+
+// Build empty public template to be populated with real reservation data if it exists.
+function buildPublicTemplate(facility, bookingWindow) {
+  let template = {};
+  for (let date of bookingWindow) {
+    let dateEntry = {};
+    for (const key of Object.keys(facility.bookingTimes)) {
+      dateEntry[key] = {
+        capacity: 'High',
+        max: checkMaxPasses(facility)
+      };
+      template[date] = dateEntry;
+    }
+  }
+  return template;
+}
+
+// Get capacity level (high, med, low, none) of a facility.
+function getCapacityLevel(base, available, modifier) {
+  const capacity = base + modifier;
+  const booked = capacity - available;
+  const percentage = booked / capacity;
+  if (percentage < LOW_CAPACITY_THRESHOLD) {
+    return 'High';
+  } else if (percentage < MODERATE_CAPACITY_THRESHOLD) {
+    return 'Moderate';
+  } else if (percentage < 1) {
+    return 'Low';
+  } else {
+    return 'Full';
+  }
+}
+
+function checkMaxPasses(facility, availablePasses = null) {
+  let max = 1;
+  switch (facility.type) {
+    case 'Parking':
+      max = PARKING_MAX_PER_PASS;
+      break;
+    case 'Trail':
+      max = TRAIL_MAX_PER_PASS;
+      break;
+  }
+  if (availablePasses > max) {
+    return max;
+  }
+  return availablePasses ?? max;
+}
+


### PR DESCRIPTION
### Jira Ticket:

BRS-774

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-774

### Description:

For accuracy of historical data, we need to ensure a new resObj is created if one doesn't exist every time the following fields of a facility are updated:

- capacity change
- modifier change
- timeslot is opened/closed
- facility is opened/closed

This change also introduces the facility open/closed status on reservation objects. If a facility opens/closes, all present & future resObjs will be updated with the new open/closed status. 
Some minor code refactoring was also done for ease of adding new fields to the resObj in the future. 
