### PR TITLE
GH Actions upgrade to Node16

### DIFF
--- a/.github/workflows/PR-Tests.yaml
+++ b/.github/workflows/PR-Tests.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [16.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
### Jira Ticket:

NOBUG

Upgrading GH actions to run Node16.
https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/