### PR TITLE
BRS-919: Fix getParkAccess call to use correct param when user != sys…

### DIFF
--- a/lambda/writePark/index.js
+++ b/lambda/writePark/index.js
@@ -29,7 +29,7 @@ exports.handler = async (event, context) => {
     if (event.httpMethod === 'PUT') {
       // Ensure PO's can update this particular park.
       if (!permissionObject.isAdmin) {
-        await getParkAccess(obj.park.orcs, permissionObject);
+        await getParkAccess(obj.sk, permissionObject);
       }
       return await updateItem(obj);
     } else {


### PR DESCRIPTION
…admin.

### Jira Ticket:

BRS-919

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-919

### Description:

This fixes an issue with role based access for those who are not a sysadmin.  It correctly passes in the park identifier instead of the orcs #.
