### PR TITLE
BRS-566 Adding booking reminder email service

### DIFF
--- a/lambda/dynamoUtil.js
+++ b/lambda/dynamoUtil.js
@@ -3,6 +3,7 @@ const { logger } = require('./logger');
 const { DateTime } = require('luxon');
 
 const TABLE_NAME = process.env.TABLE_NAME || 'parksreso';
+const EXTRAS_TABLE_NAME = process.env.EXTRAS_TABLE_NAME || 'migrations';
 const options = {
   region: 'ca-central-1'
 };
@@ -277,6 +278,7 @@ module.exports = {
   PASS_TYPE_EXPIRY_HOURS,
   TIMEZONE,
   TABLE_NAME,
+  EXTRAS_TABLE_NAME,
   dynamodb,
   setStatus,
   runQuery,

--- a/lambda/gcNotifyUtils.js
+++ b/lambda/gcNotifyUtils.js
@@ -1,0 +1,45 @@
+const axios = require('axios');
+
+/**
+ * An Axios 'post' call to GC Notify used to deliver single or bulk emails.
+ * @param {*} url The url of the GC Notify Api endpoint (different for single/bulk operations).
+ * @param {*} apiKey The API key of the GC Notify service.
+ * @param {*} data Object containing the request JSON payload.
+ * @returns Object containing `statusCode`, `data`, and `errors` of Axios response.
+ */
+// Sample bulk data param:
+// data = {
+//  name: name of the job
+//  template_id: GCN email template
+//  rows: bulk rows to send   
+// }
+async function gcnSend(url, apiKey, data) {
+  let response;
+  try {
+    const res = await axios({
+      method: 'post',
+      url: url,
+      headers: {
+        Authorization: apiKey,
+        'Content-Type': 'application/json'
+      },
+      data: data
+    });
+    response = {
+      statusCode: res?.status || 200,
+      data: res,
+      errors: null
+    }
+  } catch (err) {
+    response = {
+      statusCode: err?.response?.status || 400,
+      data: err,
+      errors: err?.response?.data?.errors || 'An unknown error occurred.'
+    }
+  }
+  return response;
+}
+
+module.exports = {
+  gcnSend
+}

--- a/lambda/rocketChatUtils.js
+++ b/lambda/rocketChatUtils.js
@@ -1,0 +1,55 @@
+const axios = require('axios');
+const { logger } = require('../logger');
+
+/**
+ * Makes a post to an existing RocketChat integration.
+ * @param {*} url RocketChat webhook URL
+ * @param {*} token RocketChat webhook bearer token
+ * @param {*} job RocketChat post payload (request)
+ * @returns Axios response.
+ */
+// request = {
+//   content: {
+//     postTitle: Title of post.
+//     postText: Body text of post.
+//     alias: RocketChat poster name.
+//     avatar: RocketChat poster profile picture.
+//     author_name: Author.
+//     author_icon: URL to author image.
+//     author_link: URL to webpage when author is clicked on.
+//     color: "#2D834F" (Hex colour).
+//     fields: [
+//       {
+//         title: Field 1 title.
+//         value: Field 1 value.
+//         short: true/false.
+//       },
+//       {
+//         title: Field 2 title.
+//         value: field 2 value.
+//         short: true/false.
+//       }
+//     ]
+//   }
+// }
+async function rcPost(url, token, job) {
+  try {
+    const rcRes = await axios({
+      method: 'post',
+      url: url,
+      headers: {
+        Authorization: token,
+        'Content-Type': 'application/json'
+      },
+      data: job,
+    });
+    return rcRes;
+  } catch (err) {
+    logger.error('Error posting alert to RocketChat:', err);
+    return err;
+  }
+}
+
+module.exports = {
+  rcPost
+}

--- a/lambda/rocketChatUtils.js
+++ b/lambda/rocketChatUtils.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const { logger } = require('../logger');
+const { logger } = require('./logger');
 
 /**
  * Makes a post to an existing RocketChat integration.
@@ -9,28 +9,26 @@ const { logger } = require('../logger');
  * @returns Axios response.
  */
 // request = {
-//   content: {
-//     postTitle: Title of post.
-//     postText: Body text of post.
-//     alias: RocketChat poster name.
-//     avatar: RocketChat poster profile picture.
-//     author_name: Author.
-//     author_icon: URL to author image.
-//     author_link: URL to webpage when author is clicked on.
-//     color: "#2D834F" (Hex colour).
-//     fields: [
-//       {
-//         title: Field 1 title.
-//         value: Field 1 value.
-//         short: true/false.
-//       },
-//       {
-//         title: Field 2 title.
-//         value: field 2 value.
-//         short: true/false.
-//       }
-//     ]
-//   }
+//   postTitle: Title of post.
+//   postText: Body text of post.
+//   alias: RocketChat poster name.
+//   avatar: RocketChat poster profile picture URL.
+//   author_name: Author.
+//   author_icon: URL to author image.
+//   author_link: URL to webpage when author is clicked on.
+//   color: "#2D834F" (Hex colour).
+//   fields: [
+//     {
+//       title: Field 1 title.
+//       value: Field 1 value.
+//       short: true/false.
+//     },
+//     {
+//       title: Field 2 title.
+//       value: field 2 value.
+//       short: true/false.
+//     }
+//   ]
 // }
 async function rcPost(url, token, job) {
   try {

--- a/lambda/sendReminder/index.js
+++ b/lambda/sendReminder/index.js
@@ -1,0 +1,203 @@
+const AWS = require('aws-sdk');
+const { runQuery, TABLE_NAME, EXTRAS_TABLE_NAME, TIMEZONE, dynamodb } = require('../dynamoUtil');
+const { gcnSend } = require('../gcNotifyUtils');
+const { rcPost } = require('../rocketChatUtils');
+const { sendResponse } = require('../responseUtil');
+const { DateTime } = require('luxon');
+const { logger } = require('../logger');
+
+
+// Default look-ahead days.
+const LOOK_AHEAD_DAYS = 1;
+// Maximum number of emails sent in a single bulk call (default for GCN is 50000).
+const MAX_BULK_SIZE = 50000;
+// Index of short dates.
+const PASS_SHORTDATE_INDEX = process.env.PASS_SHORTDATE_INDEX || 'shortPassDate-index';
+
+exports.handler = async (event, context) => {
+  console.log('Send Reminder Emails', event);
+
+  // environment variables are cast as strings
+  if (process.env.GC_NOTIFY_IS_SENDING_REMINDERS !== 'true') {
+    return sendResponse(200, { msg: `Email reminders are currently disabled.` });
+  }
+
+  // Get all passes that will be active at the look-ahead time. 
+  try {
+    // Determine look-ahead date
+    // Done this way to account for rollovers at the end of months & years
+    // We have a shortPassDate-index to query the short date, in PT, that the passes are for. 
+    // Using the shortPassDate-index to query short dates is only valid because all the parks live in PT. 
+    // If this code is used in other contexts, timezone may have to be considered when querying passes. 
+    // As a default: The cronjob will fire at 00:00 UTC
+    const todayPST = DateTime.now().setZone(TIMEZONE); // today's datetime in PT
+    const futurePST = todayPST.plus({ days: LOOK_AHEAD_DAYS });// add LOOK_AHEAD_DAYS to datetime
+    const lookAheadPST = futurePST.toISODate() // Look-ahead short date in PT
+
+    // Construct query for all passes reserved for the look-ahead date (PT)
+    // Query on index 'shortPassDate-index' to collect passes for all parks at once
+    let queryObj = {
+      TableName: TABLE_NAME,
+      IndexName: PASS_SHORTDATE_INDEX,
+      ExpressionAttributeValues: {
+        ':status': { S: 'reserved' },
+        ':shortPassDate': { S: lookAheadPST },
+      },
+      KeyConditionExpression: 'shortPassDate = :shortPassDate',
+      FilterExpression: 'passStatus = :status'
+    };
+    const passData = await runQuery(queryObj);
+    if (passData) {
+      logger.debug(passData.length + ' pass(es) fetched.');
+    } else {
+      logger.debug('No passes found.');
+    }
+
+    // Construct array of data to pass to GCNotify.
+    // Entries must follow the order of the bulkReminderRows array:
+    // Note: an empty list will have length = 1.
+    const headerRow = [["email address", "park", "facility", "date", "type", "registrationNumber", "cancellationLink"]];
+
+    // An object containing the passes to be sent via GCN, divided into MAX_BULK_SIZE chunks.
+    let bulkReminderObject = [];
+
+    if (passData) {
+      for (let i = 0; i < passData.length; i += MAX_BULK_SIZE) {
+        let bulkReminderChunk = [...headerRow];
+        let passChunk = passData.slice(i, i + MAX_BULK_SIZE);
+        for (let pass of passChunk) {
+          const row = [
+            pass.email || null,
+            pass.pk.split('::')[1] || null,
+            pass.facilityName || null,
+            pass.shortPassDate || null,
+            pass.type || null,
+            pass.sk || null,
+            buildCancellationLink(pass)
+          ];
+          bulkReminderChunk.push(row);
+        }
+        bulkReminderObject.push(bulkReminderChunk);
+      }
+    }
+
+    bulkJobSuccesses = 0;
+    bulkJobFailures = 0;
+
+    if (bulkReminderObject.length > 0) {
+      // There are passes in the system.
+      for (const chunk of bulkReminderObject) {
+        let resData;
+        let jobError = '';
+        try {
+          // Try to send a bulk batch of reminder emails.
+          let gcnSendObj = {
+            name: `DUP bulk reminders: sent ${DateTime.utc().toISO()}.`,
+            template_id: process.env.GC_NOTIFY_REMINDER_TEMPLATE_ID,
+            rows: chunk
+          };
+          const res = await gcnSend(process.env.GC_NOTIFY_API_BULK_PATH, process.env.GC_NOTIFY_API_KEY, gcnSendObj);
+          if (res.errors) {
+            resData = res?.data?.response?.data;
+            jobError = 'GC Notify encountered a problem while trying to send a bulk email to DUP users.';
+            logger.error(jobError);
+            bulkJobFailures++;
+          } else {
+            resData = res?.data?.data?.data;
+            bulkJobSuccesses++;
+          }
+        } catch (err) {
+          jobError = 'The service was unsuccessful in leveraging GC Notify to send a bulk email.';
+          resData = String(err);
+          logger.error(jobError, err)
+          bulkJobFailures++;
+        }
+
+        try {
+          // Post a summary of job success/failure to db.
+          let jobObj = await postBulkReminderSummary(resData, jobError, chunk);
+          if (jobError) {
+            // Post alert to RocketChat channel if job fails.
+            request = {
+              postTitle: '@all **Day Use Pass - Bulk Email Service**',
+              postText: `A bulk email reminder job has failed: ${jobError} Details can be found under the job key listed below.`,
+              author_name: 'Day Use Pass',
+              author_icon: 'https://bcparks.ca/_shared/images/logos/logo-bcparks-v-200.png',
+              color: '#2D834F',
+              fields: [
+                {
+                  title: 'Job key:',
+                  value: `pk: ${jobObj?.pk}\nsk: ${jobObj?.sk}`,
+                  short: true
+                },
+                {
+                  title: 'Number of users affected',
+                  value: `${chunk.length - 1}`,
+                  short: true
+                }
+              ]
+            }
+            await rcPost(process.env.RC_ALERT_WEBHOOK_URL, process.env.RC_ALERT_WEBHOOK_TOKEN, request);
+          }
+        } catch (err) {
+          logger.error('Failed to document the bulk email job:', err);
+        }
+      }
+    } else {
+      logger.debug('No passes found for reminder service.')
+    }
+    const totalJobs = bulkJobSuccesses + bulkJobFailures;
+    logger.debug(`${totalJobs} job(s) run (${bulkJobSuccesses} succeeded, ${bulkJobFailures} failed).`)
+  } catch (err) {
+    // Something unknown went wrong.
+    return sendResponse(400, { msg: 'Something went wrong.', title: 'Operation Failed' });
+  }
+}
+
+// Construct pass cancellation links to include in reminder emails.
+function buildCancellationLink(pass) {
+  const cancellationLink = process.env.PUBLIC_FRONTEND +
+    process.env.PASS_CANCELLATION_ROUTE +
+    '?passId=' +
+    pass.sk +
+    '&email=' +
+    pass.email +
+    '&park=' +
+    pass.pk.split('::')[1] +
+    '&date=' +
+    pass.shortPassDate +
+    '&type=' +
+    pass.type;
+  return cancellationLink;
+}
+
+async function postBulkReminderSummary(data, jobError, passArray) {
+  let passes = [];
+  let postItem;
+  if (passArray && jobError) {
+    // We want a list of passes.
+    for (let i = 1; i < passArray.length; i++) {
+      passes.push(passArray[i][5]);
+    }
+  }
+  try {
+    postItem = {
+      pk: 'sendReminderSummary',
+      sk: DateTime.utc().toISO(),
+      status: jobError ? 'fail' : 'success',
+      response: data,
+      passes: passes,
+    };
+    let postObj = {
+      TableName: EXTRAS_TABLE_NAME,
+      Item: AWS.DynamoDB.Converter.marshall(postItem),
+      ConditionExpression: 'attribute_not_exists(pk) AND attribute_not_exists(sk)',
+    };
+    await dynamodb.putItem(postObj).promise();
+    logger.debug('Posted bulkReminderSummary to database:', postItem);
+    return postItem;
+  } catch (err) {
+    logger.error('Failed to save bulkReminderSummary to database:', err);
+    return postItem;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mockdate": "^3.0.5",
     "read-excel-file": "^5.3.4",
     "serverless": "^3.18.1",
+    "serverless-dotenv-plugin": "^4.0.2",
     "serverless-dynamodb-local": "^0.2.40",
     "serverless-offline": "^8.2.0",
     "serverless-plugin-include-dependencies": "^5.0.0"

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,6 +18,8 @@ plugins:
   - serverless-dynamodb-local
   - serverless-offline
   - serverless-plugin-include-dependencies
+  - serverless-dotenv-plugin
+
 functions:
   ###########
   # captcha
@@ -204,6 +206,9 @@ functions:
     package:
       patterns:
         - lambda/warmUp/worker.js
+  # aws lambda invoke /dev/null --endpoint-url http://localhost:3002 --function-name parks-reso-api-api-sendReminder
+  sendReminder:
+    handler: lambda/sendReminder/index.handler
 
 custom:
   dynamodb:
@@ -287,4 +292,3 @@ resources:
             ProvisionedThroughput:
               ReadCapacityUnits: 1
               WriteCapacityUnits: 1
-

--- a/terraform/src/params.tf
+++ b/terraform/src/params.tf
@@ -2,6 +2,26 @@ data "aws_ssm_parameter" "db_name" {
   name = "/parks-reso-api/db-name"
 }
 
+data "aws_ssm_parameter" "extras_table_name" {
+  name = "/parks-reso-api/extras-table-name"
+}
+
+data "aws_ssm_parameter" "pass_shortdate_index" {
+  name = "/parks-reso-api/pass-shortdate-index"
+}
+
+data "aws_ssm_parameter" "rc_alert_webhook_url" {
+  name = "/parks-reso-api/rc-alert-webhook-url"
+}
+
+data "aws_ssm_parameter" "rc_alert_webhook_token" {
+  name = "/parks-reso-api/rc-alert-webhook-token"
+}
+
+data "aws_ssm_parameter" "gc_notify_api_bulk_path" {
+  name = "/parks-reso-api/gc-notify-api-bulk-path"
+}
+
 data "aws_ssm_parameter" "gc_notify_api_path" {
   name = "/parks-reso-api/gc-notify-api-path"
 }
@@ -16,6 +36,14 @@ data "aws_ssm_parameter" "gc_notify_parking_receipt_template_id" {
 
 data "aws_ssm_parameter" "gc_notify_trail_receipt_template_id" {
   name = "/parks-reso-api/gc-notify-trail-receipt-template-id"
+}
+
+data "aws_ssm_parameter" "gc_notify_reminder_template_id" {
+  name = "/parks-reso-api/gc-notify-reminder-template-id"
+}
+
+data "aws_ssm_parameter" "gc_notify_is_sending_reminders" {
+  name = "/parks-reso-api/gc-notify-is-sending-reminders"
 }
 
 data "aws_ssm_parameter" "gc_notify_cancel_template_id" {

--- a/terraform/src/reminderJob.tf
+++ b/terraform/src/reminderJob.tf
@@ -1,0 +1,55 @@
+resource "aws_lambda_function" "send_reminder" {
+  function_name = "sendReminder"
+
+  filename         = "artifacts/sendReminder.zip"
+  source_code_hash = filebase64sha256("artifacts/sendReminder.zip")
+
+  handler = "lambda/sendReminder/index.handler"
+  runtime = "nodejs14.x"
+  timeout = 300
+  publish = "true"
+
+  environment {
+    variables = {
+      TABLE_NAME                      = data.aws_ssm_parameter.db_name.value,
+      EXTRAS_TABLE_NAME               = data.aws_ssm_parameter.extras_table_name.value,
+      PUBLIC_FRONTEND                 = data.aws_ssm_parameter.public_url.value,
+      PASS_CANCELLATION_ROUTE         = data.aws_ssm_parameter.pass_cancellation_route.value,
+      PASS_SHORTDATE_INDEX            = data.aws_ssm_parameter.pass_shortdate_index.value, 
+      GC_NOTIFY_API_BULK_PATH         = data.aws_ssm_parameter.gc_notify_api_bulk_path.value, 
+      GC_NOTIFY_API_KEY               = data.aws_ssm_parameter.gc_notify_api_key.value, 
+      GC_NOTIFY_REMINDER_TEMPLATE_ID  = data.aws_ssm_parameter.gc_notify_reminder_template_id.value, 
+      GC_NOTIFY_IS_SENDING_REMINDERS  = data.aws_ssm_parameter.gc_notify_is_sending_reminders.value,
+      RC_ALERT_WEBHOOK_URL            = data.aws_ssm_parameter.rc_alert_webhook_url.value,
+      RC_ALERT_WEBHOOK_TOKEN          = data.aws_ssm_parameter.rc_alert_webhook_token.value,
+    }
+  }
+  role = aws_iam_role.readRole.arn
+}
+
+resource "aws_lambda_alias" "send_reminder_latest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.send_reminder.function_name
+  function_version = aws_lambda_function.send_reminder.version
+}
+
+# Every day at 00:00 UTC (16:00 or 17:00 PDT/PST) = cron(0 0 * * ? *)
+resource "aws_cloudwatch_event_rule" "send_reminder_cronjob" {
+  name                = "send_reminder_cronjob"
+  description         = "Sends scheduled pass reminder at 16:00 PST/17:00 PDT"
+  schedule_expression = "cron(0 0 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "send_reminder_cronjob_target" {
+  rule      = aws_cloudwatch_event_rule.send_reminder_cronjob.name
+  target_id = "send_reminder"
+  arn       = aws_lambda_function.send_reminder.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_send_reminder" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.send_reminder.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.send_reminder_cronjob.arn
+}

--- a/tools/rocketchat-script-example.js
+++ b/tools/rocketchat-script-example.js
@@ -1,0 +1,54 @@
+// Copy the script class below into the script box of your RC Integration and change as necessary.
+class Script {
+  // request = {
+  //   content: {
+  //     postTitle: Title of post.
+  //     postText: Body text of post
+  //     alias: RocketChat poster name
+  //     avatar: RocketChat poster profile picture
+  //     author_name: Author
+  //     author_icon: "https://bcparks.ca/_shared/images/logos/logo-bcparks-v-200.png",
+  //     author_link: url to webpage when author is clicked on
+  //     color: "#2D834F" (Hex colour),
+  //     fields: [
+  //       {
+  //         title: Field 1 title
+  //         value: Field 1 value
+  //         short: true/false
+  //       },
+  //       {
+  //         title: Field 2 title
+  //         value: field 2 value
+  //         short: true/false
+  //       }
+  //     ]
+  //   }
+  // }
+  process_incoming_request({ request }) {
+    let fields = [];
+    for (const field of request.content.fields) {
+      fields.push({
+        title: field.title,
+        value: field.value,
+        short: field.short
+      });
+    }
+    let attachments = {
+      author_name: request.content.author_name,
+      author_icon: request.content.author_icon,
+      author_link: request.content.author_link,
+      text: request.content.postText,
+      color: request.content.color,
+      fields: fields
+    };
+
+    return {
+      content: {
+        alias: request.content.alias || "sPARKy",
+        avatar: request.content.avatar || "https://chat.developer.gov.bc.ca/avatar/room/7LDi27DsXy2N2XMEa",
+        text: request.content.postTitle || '',
+        attachments: [attachments]
+      }
+    };
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3109,12 +3109,17 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dotenv-expand@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-8.0.3.tgz#29016757455bcc748469c83a19b36aaf2b83dd6e"
+  integrity sha512-SErOMvge0ZUyWd5B0NXMQlDkN+8r+HhVUsxgOO7IoPDOdDRD2JjExpN6y3KnFR66jsJMwSn1pqIivhU5rcJiNg==
+
 dotenv-expand@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-9.0.0.tgz#1fd37e2cd63ea0b5f7389fb87256efc38b035b26"
   integrity sha512-uW8Hrhp5ammm9x7kBLR6jDfujgaDarNA02tprvZdyrJ7MpdzD1KyrIHG4l+YoC2fJ2UcdFdNWNWIjt+sexBHJw==
 
-dotenv@^16.0.3:
+dotenv@^16.0.1, dotenv@^16.0.3:
   version "16.0.3"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
   integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
@@ -6330,6 +6335,15 @@ semver@^7.1.1, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
+
+serverless-dotenv-plugin@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/serverless-dotenv-plugin/-/serverless-dotenv-plugin-4.0.2.tgz#98c09236f487496235c89308090551b3ce6e15a3"
+  integrity sha512-MOXsSSuJPMAiNp7bVvvCC+ahmEMMohlaPpaVU2w4wFgMVSvs+BU7xIwQGv/7TTMNdjYVS/W2JoS5ZSkCdjHzCg==
+  dependencies:
+    chalk "^4.1.2"
+    dotenv "^16.0.1"
+    dotenv-expand "^8.0.3"
 
 serverless-dynamodb-local@^0.2.40:
   version "0.2.40"


### PR DESCRIPTION
### Jira Ticket:

BRS-566

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-566

### Description:

This change introduces a cronjob that fires every day at 00:00 UTC (16:00 or 17:00 PT). When fired, it collects every `reserved` pass for every park 1 day in advance, then sends a reminder email to those passes using GCN. 

The service can be turned off by changing the `aws_ssm_parameter = gc-notify-is-sending-reminders` to anything but `'true'` in all environments. 

Also added in this PR: Utils for GCN and RocketChat.

GCN Utils: Added a util that leverages `axios` to perform an http POST to GCN. You must provide the GCN template url, API key, and request body. Refer to GCN's API documentation to learn the structure of the request body. The util `gcnSend` can be used for both single and bulk email calls, though the request body structure will differ between both.

RocketChat Utils: Added a util that sends a customizable alert to a specified integration in RocketChat.  You must provide the integration url and bearer token, and the body of your alert. There is an example body in the `rocketChatUtils.js` file, and a sample RocketChat integration script in `tools/rocketchat-script-example.js` so that new integrations can be made in the future.

Two separate RC integrations have been created. They are nearly identical, except one points to the `osprey-sandbox` channel (local, dev, test), and the other points to `osprey-alerts` (prod). This is to filter out false alerts in the `alerts` channel.