### PR TITLE
BRS-566: giving reminderJob write perms

### DIFF
--- a/lambda/dynamoUtil.js
+++ b/lambda/dynamoUtil.js
@@ -3,7 +3,7 @@ const { logger } = require('./logger');
 const { DateTime } = require('luxon');
 
 const TABLE_NAME = process.env.TABLE_NAME || 'parksreso';
-const EXTRAS_TABLE_NAME = process.env.EXTRAS_TABLE_NAME || 'migrations';
+const META_TABLE_NAME = process.env.META_TABLE_NAME || 'parksreso-meta';
 const options = {
   region: 'ca-central-1'
 };
@@ -278,7 +278,7 @@ module.exports = {
   PASS_TYPE_EXPIRY_HOURS,
   TIMEZONE,
   TABLE_NAME,
-  EXTRAS_TABLE_NAME,
+  META_TABLE_NAME,
   dynamodb,
   setStatus,
   runQuery,

--- a/lambda/sendReminder/index.js
+++ b/lambda/sendReminder/index.js
@@ -1,5 +1,5 @@
 const AWS = require('aws-sdk');
-const { runQuery, TABLE_NAME, EXTRAS_TABLE_NAME, TIMEZONE, dynamodb } = require('../dynamoUtil');
+const { runQuery, TABLE_NAME, META_TABLE_NAME, TIMEZONE, dynamodb } = require('../dynamoUtil');
 const { gcnSend } = require('../gcNotifyUtils');
 const { rcPost } = require('../rocketChatUtils');
 const { sendResponse } = require('../responseUtil');
@@ -193,7 +193,7 @@ async function postBulkReminderSummary(data, jobError, passArray) {
       passes: passes,
     };
     let postObj = {
-      TableName: EXTRAS_TABLE_NAME,
+      TableName: META_TABLE_NAME,
       Item: AWS.DynamoDB.Converter.marshall(postItem),
       ConditionExpression: 'attribute_not_exists(pk) AND attribute_not_exists(sk)',
     };

--- a/terraform/src/db.tf
+++ b/terraform/src/db.tf
@@ -78,6 +78,31 @@ resource "aws_dynamodb_table" "park_dup_table" {
   }
 }
 
+resource "aws_dynamodb_table" "park_dup_meta_table" {
+  name           = data.aws_ssm_parameter.meta_db_name.value
+  hash_key       = "pk"
+  range_key      = "sk"
+  billing_mode   = "PAY_PER_REQUEST"
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = {
+    Name = "Database"
+  }
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+}
+
 resource "aws_backup_vault" "parksreso_backup_vault" {
   name        = "backup_vault_for_parksreso"
 }

--- a/terraform/src/params.tf
+++ b/terraform/src/params.tf
@@ -2,8 +2,8 @@ data "aws_ssm_parameter" "db_name" {
   name = "/parks-reso-api/db-name"
 }
 
-data "aws_ssm_parameter" "extras_table_name" {
-  name = "/parks-reso-api/extras-table-name"
+data "aws_ssm_parameter" "meta_db_name" {
+  name = "/parks-reso-api/meta-db-name"
 }
 
 data "aws_ssm_parameter" "pass_shortdate_index" {

--- a/terraform/src/reminderJob.tf
+++ b/terraform/src/reminderJob.tf
@@ -12,7 +12,7 @@ resource "aws_lambda_function" "send_reminder" {
   environment {
     variables = {
       TABLE_NAME                      = data.aws_ssm_parameter.db_name.value,
-      EXTRAS_TABLE_NAME               = data.aws_ssm_parameter.extras_table_name.value,
+      META_TABLE_NAME                 = data.aws_ssm_parameter.meta_db_name.value,
       PUBLIC_FRONTEND                 = data.aws_ssm_parameter.public_url.value,
       PASS_CANCELLATION_ROUTE         = data.aws_ssm_parameter.pass_cancellation_route.value,
       PASS_SHORTDATE_INDEX            = data.aws_ssm_parameter.pass_shortdate_index.value, 
@@ -24,7 +24,7 @@ resource "aws_lambda_function" "send_reminder" {
       RC_ALERT_WEBHOOK_TOKEN          = data.aws_ssm_parameter.rc_alert_webhook_token.value,
     }
   }
-  role = aws_iam_role.readRole.arn
+  role = aws_iam_role.metaWriteRole.arn
 }
 
 resource "aws_lambda_alias" "send_reminder_latest" {

--- a/terraform/src/roles.tf
+++ b/terraform/src/roles.tf
@@ -185,6 +185,27 @@ EOF
 
 }
 
+resource "aws_iam_role" "metaWriteRole" {
+  name = "lambdaMetaWriteRole"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+}
+
 resource "aws_iam_role" "deleteRole" {
   name = "lambdaDeleteRole"
 
@@ -405,6 +426,62 @@ resource "aws_iam_role_policy" "dynamoDBWriteRole" {
             "dynamodb:ConditionCheckItem"
         ],
         "Resource": "${aws_dynamodb_table.park_dup_table.arn}"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:Query"
+        ],
+        "Resource": "${aws_dynamodb_table.park_dup_table.arn}/index/*"
+      }
+    ]
+  }
+  EOF
+}
+
+resource "aws_iam_role_policy" "dynamoDBMetaWriteRole" {
+  name = "park_reso_dynamodb_meta"
+  role = aws_iam_role.metaWriteRole.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:BatchGet*",
+            "dynamodb:DescribeStream",
+            "dynamodb:DescribeTable",
+            "dynamodb:Get*",
+            "dynamodb:Query",
+            "dynamodb:Scan",
+            "dynamodb:BatchWrite*",
+            "dynamodb:CreateTable",
+            "dynamodb:Delete*",
+            "dynamodb:Update*",
+            "dynamodb:PutItem",
+            "dynamodb:ConditionCheckItem"
+        ],
+        "Resource": "${aws_dynamodb_table.park_dup_table.arn}"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:BatchGet*",
+            "dynamodb:DescribeStream",
+            "dynamodb:DescribeTable",
+            "dynamodb:Get*",
+            "dynamodb:Query",
+            "dynamodb:Scan",
+            "dynamodb:BatchWrite*",
+            "dynamodb:CreateTable",
+            "dynamodb:Delete*",
+            "dynamodb:Update*",
+            "dynamodb:PutItem",
+            "dynamodb:ConditionCheckItem"
+        ],
+        "Resource": "${aws_dynamodb_table.park_dup_meta_table.arn}"
       },
       {
         "Effect": "Allow",


### PR DESCRIPTION
### Jira Ticket:

BRS-566

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-566

### Description:

This change introduces a new `dynamodb` table `parksreso-meta` for containing system metadata like `sendReminderSummary` job objects.

Developers: for your `.bashrc` convenience:

```
aws dynamodb create-table \
    --table-name parksreso-meta \
    --attribute-definitions \
        AttributeName=pk,AttributeType=S \
        AttributeName=sk,AttributeType=S \
    --key-schema \
        AttributeName=pk,KeyType=HASH \
        AttributeName=sk,KeyType=RANGE \
    --billing-mode PAY_PER_REQUEST \
    --provisioned-throughput \
        ReadCapacityUnits=1,WriteCapacityUnits=1 \
    --region local-env --endpoint-url=http://localhost:8000/
```
