### PR TITLE
BRS-916: removing audit trail from pass export

### DIFF
--- a/lambda/exportPass/index.js
+++ b/lambda/exportPass/index.js
@@ -89,7 +89,11 @@ exports.handler = async (event, context) => {
       let passData;
       do {
         passData = await runQuery(queryObj, true);
-        passData.data.forEach((item) => scanResults.push(item));
+        passData.data.forEach((item) => {
+          // Delete audit trail (BRS-916)
+          delete item.audit;
+          scanResults.push(item)
+        });
         queryObj.ExclusiveStartKey = passData.LastEvaluatedKey;
       } while (typeof passData.LastEvaluatedKey !== "undefined");
 


### PR DESCRIPTION
### Jira Ticket:

BRS-916

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-916

### Description:

Note that this change, in accordance with ticket BRS-916, only removes the audit trail from the exporter on the facility's pass list page. The metrics page exporter still exports audit trail information.
