### PR TITLE
BRS-794 Part 1: idempotent migration scripts

### DIFF
--- a/tools/pksk-migration/parks/common.js
+++ b/tools/pksk-migration/parks/common.js
@@ -1,0 +1,33 @@
+const { getParks } = require('../../../lambda/dynamoUtil');
+
+function formatTime(time) {
+  let sec = parseInt(time / 1000, 10);
+  let hours = Math.floor(sec / 3600);
+  let minutes = Math.floor((sec - (hours * 3600)) / 60);
+  let seconds = sec - (hours * 3600) - (minutes * 60);
+  if (hours < 10) { hours = "0" + hours; }
+  if (minutes < 10) { minutes = "0" + minutes; }
+  if (seconds < 10) { seconds = "0" + seconds; }
+  return hours + ':' + minutes + ':' + seconds;
+}
+
+function updateConsoleProgress(startTime, intervalStartTime, text, complete = 0, total = 1, modulo = 1) {
+  if (complete % modulo === 0 || complete === total) {
+    const currentTime = new Date().getTime();
+    let currentElapsed = formatTime(currentTime - intervalStartTime);
+    let totalElapsed = formatTime(currentTime - startTime);
+    const percent = (complete / total) * 100;
+    process.stdout.write(` ${text}: ${complete}/${total} (${percent.toFixed(1)}%) completed in ${currentElapsed} (${totalElapsed} elapsed)\r`);
+  }
+}
+
+async function getOldParks() {
+  let parks = await getParks();
+  let oldParks = parks.filter((park) => park.sk !== park.orcs);
+  return oldParks;
+}
+
+module.exports = {
+  updateConsoleProgress,
+  getOldParks
+}

--- a/tools/pksk-migration/parks/create.js
+++ b/tools/pksk-migration/parks/create.js
@@ -1,0 +1,292 @@
+'use strict';
+const AWS = require('aws-sdk');
+const { TABLE_NAME, dynamodb, getFacilities, runQuery } = require('../../../lambda/dynamoUtil');
+const { logger } = require('../../../lambda/logger');
+const { getOldParks, updateConsoleProgress } = require('./common')
+
+// This is a migration script built for BRS-794 which aims to update the primary keys of park and 
+// facilities in the database to be unique indentifiers instead of a name. 
+// This script should run before the delete script.
+// Create copies of parks, facilities, and reservation objects in the DB using parks ORCS as park sk.
+// Objects will ONLY create if they do not already exist, so this script can be run multiple times. 
+
+let startTime = new Date().getTime();
+let intervalStartTime = new Date().getTime();
+
+async function createNew() {
+
+  // create new db objects since we cannot update primary keys
+  await createNewParks();
+  await createNewFacilities();
+  await createNewResObjects();
+  await createNewPasses();
+
+};
+
+async function createNewParks() {
+  console.log('********************');
+  console.log('Creating new parks with ORCS sort key...');
+
+  const parks = await getOldParks();
+  let failParksList = [];
+  let successParksList = []
+
+  try {
+    intervalStartTime = new Date().getTime();
+    for (const park of parks) {
+      updateConsoleProgress(startTime, intervalStartTime, 'Park progress', parks.indexOf(park) + 1, parks.length, 1);
+
+      // ignore parks that already have new orcs sk.
+      if (park.sk !== park.orcs) {
+
+        // create new park object
+        let newPark = { ...park };
+
+        if (park.orcs) {
+          newPark.sk = park.orcs
+
+          // post new park object
+          const parkPostObj = {
+            TableName: TABLE_NAME,
+            Item: AWS.DynamoDB.Converter.marshall(newPark),
+            ConditionExpression: "pk <> :pk AND sk <> :sk",
+            ExpressionAttributeValues: {
+              ":pk": { S: newPark.pk },
+              ":sk": { S: newPark.sk }
+            }
+          }
+          try {
+            await dynamodb.putItem(parkPostObj).promise();
+            successParksList.push(newPark);
+          } catch (err) {
+            // post failed, item likely already exists
+            failParksList.push({ parkSk: newPark.sk, reason: 'PUT Failed: ' + err })
+          }
+        } else {
+          // old park is malformed
+          failParksList.push({ parkSk: park.sk, reason: 'Missing/Invalid ORCS' });
+        }
+      } else {
+        // item already exists
+        failParksList.push({ parkSk: park.sk, reason: 'Already updated' });
+      }
+    }
+    if (failParksList.length) {
+      logger.debug('Failed park creations:\n', failParksList);
+    }
+  } catch (error) {
+    logger.debug('Error creating new parks:', error);
+  }
+  console.log('\nNew parks created:', successParksList?.length || 0);
+  console.log('********************\n');
+}
+
+async function createNewFacilities() {
+  console.log('********************');
+  console.log('Creating new facilites with new parks orcs partition key...');
+
+  let failFacilitiesList = [];
+  let successFacilitiesList = []
+
+  const oldParks = await getOldParks();
+
+  try {
+    for (const park of oldParks) {
+      const facilities = await getFacilities(park.sk);
+      intervalStartTime = new Date().getTime();
+      for (const facility of facilities) {
+        updateConsoleProgress(startTime, intervalStartTime, `${park.sk} - facility progress`, facilities.indexOf(facility) + 1, facilities.length, 1);
+
+        // ignore facilities that already have new orcs pk integration.
+        if (facility.pk !== `facility::${park.orcs}`) {
+
+          //create new facility object
+          let newFacility = { ...facility };
+          if (park.orcs) {
+            newFacility.pk = `facility::${park.orcs}`;
+            // post new park object
+            const facilityPostObj = {
+              TableName: TABLE_NAME,
+              Item: AWS.DynamoDB.Converter.marshall(newFacility),
+              ConditionExpression: "pk <> :pk AND sk <> :sk",
+              ExpressionAttributeValues: {
+                ":pk": { S: newFacility.pk },
+                ":sk": { S: newFacility.sk }
+              }
+            }
+            try {
+              await dynamodb.putItem(facilityPostObj).promise();
+              successFacilitiesList.push(newFacility);
+            } catch (err) {
+              // post failed, item likely already exists
+              failFacilitiesList.push({ facilitySk: newFacility.sk, reason: 'PUT failed: ' + err })
+            }
+          } else {
+            // malformed parent park object
+            failFacilitiesList.push({ facilitySk: facility.sk, reason: 'Parent park is missing ORCS' });
+          }
+        } else {
+          // item already exists
+          failFacilitiesList.push({ facilitySk: facility.sk, reason: 'Already updated' });
+        }
+      }
+      // newline for every park
+      process.stdout.write('\n')
+    }
+    if (failFacilitiesList.length) {
+      logger.debug('Failed facility creations:\n', failFacilitiesList);
+    }
+  } catch (error) {
+    logger.debug('Error creating new facilities:', error);
+  }
+  console.log('\nNew facilities created:', successFacilitiesList?.length || 0);
+  console.log('********************\n');
+}
+
+async function createNewResObjects() {
+  console.log('********************');
+  console.log('Creating new reservation objects with new parks orcs partition key...\n');
+
+  let failResObjList = [];
+  let successResObjList = [];
+
+  const oldParks = await getOldParks();
+  try {
+    for (const park of oldParks) {
+      const facilities = await getFacilities(park.sk)
+
+      for (const facility of facilities) {
+        // run query for all resobjects
+        const resObjQuery = {
+          TableName: TABLE_NAME,
+          KeyConditionExpression: 'pk = :pk',
+          ExpressionAttributeValues: {
+            ':pk': { S: `reservations::${park.name}::${facility.sk}` }
+          }
+        }
+
+        let res;
+        try {
+          res = await runQuery(resObjQuery);
+        } catch (err) {
+          logger.debug('Error getting old reservation objects;', err);
+        }
+
+        intervalStartTime = new Date().getTime();
+        for (const reservation of res) {
+          updateConsoleProgress(startTime, intervalStartTime, `${facility.sk} (${park.sk}) - resObj progress`, res.indexOf(reservation) + 1, res.length, 1);
+
+          // ignore reservation objects that already have new orcs pk integration.
+          if (reservation.pk !== `reservations::${park.orcs}::${facility.sk}`) {
+
+            let newReservationObj = { ...reservation };
+            newReservationObj.pk = `reservations::${park.orcs}::${facility.sk}`
+            const reservationPostObj = {
+              TableName: TABLE_NAME,
+              Item: AWS.DynamoDB.Converter.marshall(newReservationObj),
+              ConditionExpression: "pk <> :pk AND sk <> :sk",
+              ExpressionAttributeValues: {
+                ":pk": { S: newReservationObj.pk },
+                ":sk": { S: newReservationObj.sk }
+              }
+            }
+            try {
+              await dynamodb.putItem(reservationPostObj).promise();
+              successResObjList.push(newReservationObj)
+            } catch (err) {
+              // put failed, item likely already exists
+              failResObjList.push({ facilitySk: facility.sk, reason: 'PUT failed: ' + err })
+            }
+          } else {
+            // item already exists
+            failResObjList.push({ ResObjSk: reservation.sk, reason: 'Already updated' });
+          }
+        }
+        if (res.length > 0) {
+          // newline for every facility
+          process.stdout.write('\n')
+        }
+      }
+    }
+    if (failResObjList.length) {
+      logger.debug('Failed resObj creations:\n', failResObjList);
+    }
+  } catch (error) {
+    console.log('Error creating new reservation objects:', error);
+  }
+  console.log('\nNew reservation objects created:', successResObjList?.length || 0);
+  console.log('********************\n');
+}
+
+async function createNewPasses() {
+  console.log('********************');
+  console.log('Creating new passes with new parks orcs partition key...\n');
+
+  let failPassList = [];
+  let successPassList = [];
+
+  const oldParks = await getOldParks();
+
+  try {
+    for (const park of oldParks) {
+      // fetch all passes
+      let passQuery = {
+        TableName: TABLE_NAME,
+        KeyConditionExpression: 'pk = :pk',
+        ExpressionAttributeValues: {
+          ':pk': { S: `pass::${park.name}` }
+        }
+      }
+
+      let passes;
+      try {
+        passes = await runQuery(passQuery);
+      } catch (err) {
+        logger.debug('Error getting passes for ', park.name, err);
+      }
+      intervalStartTime = new Date().getTime();
+      for (const pass of passes) {
+        updateConsoleProgress(startTime, intervalStartTime, `${park.sk} - pass progress`, passes.indexOf(pass) + 1, passes.length, 100);
+
+        // ignore passes that already have new orcs pk integration, May occur if migration is interrupted.
+        if (pass.pk !== `pass::${park.orcs}`) {
+
+          let newPass = { ...pass };
+          // include parkName in pass data - needed for GCN props
+          newPass['parkName'] = park.name;
+          newPass.pk = `pass::${park.orcs}`;
+          const passPostObj = {
+            TableName: TABLE_NAME,
+            Item: AWS.DynamoDB.Converter.marshall(newPass),
+            ConditionExpression: "pk <> :pk AND sk <> :sk",
+            ExpressionAttributeValues: {
+              ":pk": { S: newPass.pk },
+              ":sk": { S: newPass.sk }
+            }
+          }
+          try {
+            await dynamodb.putItem(passPostObj).promise();
+            successPassList.push(newPass);
+          } catch (err) {
+            // PUT failed, item likely already exists
+            failPassList.push({ passSk: newPass.sk, reason: 'PUT failed: ' + err });
+          }
+        } else {
+          failPassList.push({ passSk: pass.sk, reason: 'Already updated' });
+        }
+      }
+      if (passes.length > 0) {
+        process.stdout.write('\n')
+      }
+    }
+    if (failPassList.length) {
+      logger.debug('Failed pass creations:\n', failPassList);
+    }
+  } catch (err) {
+    console.log('Error creating new passes:', err);
+  }
+  console.log('\nNew passes created:', successPassList?.length || 0);
+  console.log('********************\n');
+}
+
+createNew();

--- a/tools/pksk-migration/parks/delete.js
+++ b/tools/pksk-migration/parks/delete.js
@@ -1,0 +1,215 @@
+'use strict';
+const { TABLE_NAME, dynamodb, getFacilities, runQuery } = require('../../../lambda/dynamoUtil');
+const { logger } = require('../../../lambda/logger');
+const { getOldParks, updateConsoleProgress } = require('./common');
+
+// This is a migration script built for BRS-794 which aims to update the primary keys of park and 
+// facilities in the database to be unique indentifiers instead of a name. 
+// This script should be run after the create script. 
+// This migration will remove all database items that use the old primary key for parks/facilities in their own keys.
+
+let startTime = new Date().getTime();
+let intervalStartTime = new Date().getTime();
+
+async function deleteOld() {
+
+  // order of these is important
+  await deleteOldPasses();
+  await deleteOldResObjects();
+  await deleteOldFacilities();
+  await deleteOldParks();
+
+};
+
+async function deleteOldParks() {
+  console.log('********************');
+  console.log('Deleting old parks without ORCS sort key...\n');
+
+  const parks = await getOldParks();
+  let failParksList = [];
+  let successParksList = [];
+
+  try {
+    intervalStartTime = new Date().getTime();
+    for (const park of parks) {
+      updateConsoleProgress(startTime, intervalStartTime, 'Park delete', parks.indexOf(park) + 1, parks.length, 1);
+      const parkDeleteObj = {
+        TableName: TABLE_NAME,
+        Key: {
+          pk: { S: park.pk },
+          sk: { S: park.sk }
+        }
+      }
+      try {
+        await dynamodb.deleteItem(parkDeleteObj).promise();
+        successParksList.push(park);
+      } catch (err) {
+        // delete failed
+        failParksList.push({ parkSk: park.sk, reason: 'DELETE failed: ' + err });
+      }
+    }
+  } catch (err) {
+    logger.debug('Error deleting old parks:', err);
+  }
+  console.log('\n\nOld parks deleted:', successParksList?.length || 0);
+  console.log('********************\n');
+}
+
+async function deleteOldFacilities() {
+  console.log('********************');
+  console.log('Deleting old facilities without ORCS sort key...\n');
+  let failFacilitiesList = [];
+  let successFacilitiesList = [];
+
+  const parks = await getOldParks();
+  try {
+    for (const park of parks) {
+      const facilities = await getFacilities(park.sk);
+      intervalStartTime = new Date().getTime();
+      for (const facility of facilities) {
+        updateConsoleProgress(startTime, intervalStartTime, `${park.sk} - facility delete`, facilities.indexOf(facility) + 1, facilities.length, 1);
+
+        const facilityDeleteObj = {
+          TableName: TABLE_NAME,
+          Key: {
+            pk: { S: facility.pk },
+            sk: { S: facility.sk }
+          }
+        }
+        try {
+          await dynamodb.deleteItem(facilityDeleteObj).promise();
+          successFacilitiesList.push(facility);
+        } catch (err) {
+          // delete failed
+          failFacilitiesList.push({ facilitySk: facility.sk, reason: 'DELETE failed: ' + err });
+        }
+      }
+      // newline for every park
+      process.stdout.write('\n')
+    }
+  } catch (err) {
+    logger.debug('Error deleting old facilities:', error);
+  }
+  console.log('\nOld facilities deleted:', successFacilitiesList?.length || 0);
+  console.log('********************\n');
+}
+
+async function deleteOldResObjects() {
+  console.log('********************');
+  console.log('Deleting old reservation objects without ORCS sort key...\n');
+  let failResObjList = [];
+  let successResObjList = [];
+
+  const parks = await getOldParks();
+  try {
+    for (const park of parks) {
+      const facilities = await getFacilities(park.sk);
+      for (const facility of facilities) {
+
+        const resObjQuery = {
+          TableName: TABLE_NAME,
+          KeyConditionExpression: 'pk = :pk',
+          ExpressionAttributeValues: {
+            ':pk': { S: `reservations::${park.name}::${facility.sk}` }
+          }
+        }
+
+        let res;
+        try {
+          res = await runQuery(resObjQuery);
+        } catch (err) {
+          logger.debug('Error getting old reservation objects;', err);
+        }
+
+        intervalStartTime = new Date().getTime();
+
+        for (const reservation of res) {
+
+          updateConsoleProgress(startTime, intervalStartTime, `${facility.sk} (${park.sk}) - reservation object delete`, res.indexOf(reservation) + 1, res.length, 1);
+
+          const resObjDeleteObj = {
+            TableName: TABLE_NAME,
+            Key: {
+              pk: { S: reservation.pk },
+              sk: { S: reservation.sk }
+            }
+          }
+          try {
+            await dynamodb.deleteItem(resObjDeleteObj).promise();
+            successResObjList.push(reservation);
+          } catch (err) {
+            // delete failed
+            failResObjList.push({ reservationSk: reservation.sk, reason: 'DELETE failed: ' + err });
+          }
+        }
+        if (res.length > 0) {
+          // newline for every facility
+          process.stdout.write('\n')
+        }
+      }
+    }
+  } catch (err) {
+    logger.debug('Error deleting old reservation objects:', err);
+  }
+  console.log('\nOld reservation objects deleted:', successResObjList?.length || 0);
+  console.log('********************\n');
+}
+
+async function deleteOldPasses() {
+  console.log('********************');
+  console.log('Deleting old passes without ORCS sort key...\n');
+  let failPassList = [];
+  let successPassList = [];
+
+  const parks = await getOldParks();
+  try {
+    for (const park of parks) {
+
+      const passQueryObj = {
+        TableName: TABLE_NAME,
+        KeyConditionExpression: 'pk = :pk',
+        ExpressionAttributeValues: {
+          ':pk': { S: `pass::${park.name}` }
+        }
+      }
+
+      let passes;
+      try {
+        passes = await runQuery(passQueryObj);
+      } catch (err) {
+        logger.debug('Error getting old passes', err);
+      }
+
+      intervalStartTime = new Date().getTime();
+
+      for (const pass of passes) {
+
+        updateConsoleProgress(startTime, intervalStartTime, `${park.sk} - pass delete`, passes.indexOf(pass) + 1, passes.length, 100);
+
+        const passDeleteObj = {
+          TableName: TABLE_NAME,
+          Key: {
+            pk: { S: pass.pk },
+            sk: { S: pass.sk }
+          }
+        }
+        try {
+          await dynamodb.deleteItem(passDeleteObj).promise();
+          successPassList.push(pass);
+        } catch (err) {
+          // delete failed
+          failPassList.push({ passSk: pass.sk, reason: 'DELETE failed: ' + err });
+        }
+      }
+      if (passes.length > 0) {
+        process.stdout.write('\n')
+      }
+    }
+  } catch (err) {
+    logger.debug('Error deleting old passes:', error);
+  }
+  console.log('\nOld passes deleted:', successPassList?.length || 0);
+  console.log('********************\n');
+}
+
+deleteOld();


### PR DESCRIPTION
### Jira Ticket:

BRS-794

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-794

### Description:

This change adds in the migration scripts that will update the primary keys of all items in the db to reflect the new proposed updates to park sk changes only. The scripts are being added now to break up the amount of review required, but the scripts will not be run until the API/FE changes are complete and ready to merge.

Since you cannot update the pk/sk of an item in dynamodb, we will have to create brand new items. This means we will have to create a new item with the correct pk/sk for nearly every item in the database, and then delete the old ones.
