### PR TITLE
BRS-934: park visitor survey email

### DIFF
--- a/lambda/sendSurvey/index.js
+++ b/lambda/sendSurvey/index.js
@@ -1,0 +1,220 @@
+const AWS = require('aws-sdk');
+const { runQuery, TABLE_NAME, META_TABLE_NAME, TIMEZONE, dynamodb } = require('../dynamoUtil');
+const { gcnSend } = require('../gcNotifyUtils');
+const { rcPost } = require('../rocketChatUtils');
+const { sendResponse } = require('../responseUtil');
+const { DateTime } = require('luxon');
+const { logger } = require('../logger');
+
+// Default look-ahead days.
+const LOOK_BEHIND_DAYS = 1;
+// Maximum number of emails sent in a single bulk call (default for GCN is 50000).
+const MAX_BULK_SIZE = 50000;
+// Index of short dates.
+const PASS_SHORTDATE_INDEX = process.env.PASS_SHORTDATE_INDEX || 'shortPassDate-index';
+// Fallback to helpshapebc homepage if no feedback survey provided
+const FEEDBACK_SURVEY_URL = process.env.FEEDBACK_SURVEY_URL || 'https://helpshapebc.gov.bc.ca/';
+const GC_NOTIFY_IS_SENDING_SURVEYS = process.env.GC_NOTIFY_IS_SENDING_SURVEYS || 'false';
+
+exports.handler = async (event, context) => {
+  logger.debug('Send Feedback Survey Emails', event);
+
+  // environment variables are cast as strings
+  if (GC_NOTIFY_IS_SENDING_SURVEYS !== 'true') {
+    return sendResponse(200, { msg: `Feedback survey emails are currently disabled.` });
+  }
+
+  // Get all passes that are expired for yesterday's sessions
+  try {
+    // We have a shortPassDate-index to query the short date, in PT, that the passes are for. 
+    // Using the shortPassDate-index to query short dates is only valid because all the parks live in PT. 
+    // If this code is used in other contexts, timezone may have to be considered when querying passes. 
+    // As a default: The cronjob will fire at 20:00 UTC
+    const todayPST = DateTime.now().setZone(TIMEZONE); // today's datetime in PT
+    const yesterdayPST = todayPST.minus({ days: LOOK_BEHIND_DAYS });// add LOOK_AHEAD_DAYS to datetime
+    const yesterdayDatePST = yesterdayPST.toISODate() // Look-ahead short date in PT
+
+    // Construct query for all passes reserved for the look-ahead date (PT)
+    // Query on index 'shortPassDate-index' to collect passes for all parks at once
+    // TODO: remove hard-coded Mt. Seymour only query.
+    let queryObj = {
+      TableName: TABLE_NAME,
+      IndexName: PASS_SHORTDATE_INDEX,
+      ExpressionAttributeValues: {
+        ':status': { S: 'expired' },
+        ':pk': {S: 'pass::0015'},
+        ':shortPassDate': { S: yesterdayDatePST },
+      },
+      KeyConditionExpression: 'shortPassDate = :shortPassDate',
+      FilterExpression: 'passStatus = :status AND pk = :pk'
+    };
+    const passData = await runQuery(queryObj);
+    if (passData.length) {
+      logger.info(passData.length + ' pass(es) fetched.');
+    } else {
+      logger.info('No passes found.');
+    }
+
+    // Construct array of data to pass to GCNotify.
+    // Entries must follow the order of the bulkEmail array.
+    // registrationNumber is not used in the email template but will be used in our metadata tracking
+    // Note: an empty list will have length = 1.
+    const headerRow = [["email address", "firstName", "park", "surveyLink", "registrationNumber"]];
+
+    // An object containing the passes to be sent via GCN, divided into MAX_BULK_SIZE chunks.
+    let bulkEmailObject = [];
+
+    if (passData.length) {
+      for (let i = 0; i < passData.length; i += MAX_BULK_SIZE) {
+        let bulkEmailChunk = [...headerRow];
+        let passChunk = passData.slice(i, i + MAX_BULK_SIZE);
+        for (let pass of passChunk) {
+          const row = [
+            pass.email || null,
+            pass.firstName || null,
+            pass.parkName || null,
+            FEEDBACK_SURVEY_URL,
+            pass.sk || null,
+          ];
+          bulkEmailChunk.push(row);
+        }
+        bulkEmailObject.push(bulkEmailChunk);
+      }
+    }
+
+    bulkJobSuccesses = 0;
+    bulkJobFailures = 0;
+
+    if (bulkEmailObject.length > 0) {
+      // There are passes in the system.
+      for (const chunk of bulkEmailObject) {
+        let resData;
+        let jobError = '';
+        try {
+          // Try to send a bulk batch of reminder emails.
+          let gcnSendObj = {
+            name: `DUP bulk feedback survey emails: sent ${DateTime.utc().toISO()}.`,
+            template_id: process.env.GC_NOTIFY_SURVEY_TEMPLATE_ID,
+            rows: chunk
+          };
+          logger.info("Sending to GC Notify");
+          const res = await gcnSend(process.env.GC_NOTIFY_API_BULK_PATH, process.env.GC_NOTIFY_API_KEY, gcnSendObj);
+          if (res.errors) {
+            resData = res?.data?.response?.data;
+            jobError = 'GC Notify encountered a problem while trying to send a bulk email to DUP users.';
+            logger.error(jobError);
+            bulkJobFailures++;
+          } else {
+            resData = res?.data?.data?.data;
+            bulkJobSuccesses++;
+          }
+        } catch (err) {
+          jobError = `The service was unsuccessful in leveraging GC Notify to send a bulk email: ${err}`;
+          resData = String(err);
+          logger.error(jobError, err)
+          bulkJobFailures++;
+        }
+        try {
+          // Post a summary of job success/failure to db.
+          let jobObj = await postBulkSummary(resData, jobError, chunk);
+          if (jobError) {
+            // Post alert to RocketChat channel if job fails.
+            sendRocketChatAlert(
+              `A bulk email reminder job has failed: ${jobError}`,
+              [
+                {
+                  title: 'Job key:',
+                  value: `pk: ${jobObj?.pk}\nsk: ${jobObj?.sk}`,
+                  short: true
+                },
+                {
+                  title: 'Number of users affected',
+                  value: `${chunk.length - 1}`,
+                  short: true
+                }
+              ]
+            );
+          }
+        } catch (err) {
+          logger.error('Failed to document the bulk email job:', err);
+        }
+      }
+    } else {
+      logger.info('No passes found for feedback survey service.')
+    }
+    const totalJobs = bulkJobSuccesses + bulkJobFailures;
+    logger.info(`${totalJobs} job(s) run (${bulkJobSuccesses} succeeded, ${bulkJobFailures} failed).`)
+  } catch (err) {
+    // Something unknown went wrong.
+    sendRocketChatAlert(
+      `A bulk feedback survey email job has failed: An unknown error occurred.`,
+      [
+        {
+          title: 'Error:',
+          value: `${err}`,
+          short: false
+        }
+      ]
+    );
+    return sendResponse(400, { msg: 'Something went wrong.', title: 'Operation Failed' });
+  }
+}
+
+async function postBulkSummary(data, jobError, passArray) {
+  let passes = [];
+  let postItem;
+  try {
+    if (passArray && jobError) {
+      // collect and save reservation numbers
+      for (let i = 1; i < passArray.length; i++) {
+        passes.push(passArray[i][4]);
+      }
+    }
+    postItem = {
+      pk: 'feedbackSurveySummary',
+      sk: DateTime.utc().toISO(),
+      status: jobError ? 'fail' : 'success',
+      response: data,
+      passes: passes,
+    };
+    let postObj = {
+      TableName: META_TABLE_NAME,
+      Item: AWS.DynamoDB.Converter.marshall(postItem),
+      ConditionExpression: 'attribute_not_exists(pk) AND attribute_not_exists(sk)',
+    };
+    await dynamodb.putItem(postObj).promise();
+    logger.debug('Posted bulk feedbackSurveySummary to database:', postItem);
+    return postItem;
+  } catch (err) {
+    sendRocketChatAlert(
+      `A bulk feedback survey email job has failed: The system was unable to save a record of the bulk email job to DynamoDB.`,
+      [
+        {
+          title: 'Error:',
+          value: `${err}`,
+          short: true
+        },
+        {
+          title: 'Number of users affected:',
+          value: `${passArray?.length - 1}`,
+          short: true
+        }
+      ]
+    );
+    logger.error('Failed to save bulk feedback survey email job to database:', err);
+    return postItem;
+  }
+}
+
+function sendRocketChatAlert(text, fields) {
+  // Post alert to RocketChat channel if job fails.
+  request = {
+    postTitle: '@all **Day Use Pass - Bulk Email Service**',
+    postText: text,
+    author_name: 'Day Use Pass',
+    author_icon: 'https://bcparks.ca/_shared/images/logos/logo-bcparks-v-200.png',
+    color: '#2D834F',
+    fields: fields
+  }
+  rcPost(process.env.RC_ALERT_WEBHOOK_URL, process.env.RC_ALERT_WEBHOOK_TOKEN, request);
+}

--- a/serverless.yml
+++ b/serverless.yml
@@ -216,6 +216,9 @@ functions:
   # aws lambda invoke /dev/null --endpoint-url http://localhost:3002 --function-name parks-reso-api-api-sendReminder
   sendReminder:
     handler: lambda/sendReminder/index.handler
+  # aws lambda invoke /dev/null --endpoint-url http://localhost:3002 --function-name parks-reso-api-api-sendSurvey
+  sendSurvey:
+    handler: lambda/sendSurvey/index.handler
 
 custom:
   dynamodb:
@@ -330,6 +333,7 @@ resources:
                 - creationDate
                 - isOverbooked
                 - parkName
+                - pk
             ProvisionedThroughput:
               ReadCapacityUnits: 1
               WriteCapacityUnits: 1

--- a/terraform/src/db.tf
+++ b/terraform/src/db.tf
@@ -60,7 +60,8 @@ resource "aws_dynamodb_table" "park_dup_table" {
       "license",
       "creationDate",
       "isOverbooked",
-      "parkName"
+      "parkName",
+      "pk"
 ]
   }
 

--- a/terraform/src/params.tf
+++ b/terraform/src/params.tf
@@ -42,8 +42,20 @@ data "aws_ssm_parameter" "gc_notify_reminder_template_id" {
   name = "/parks-reso-api/gc-notify-reminder-template-id"
 }
 
+data "aws_ssm_parameter" "gc_notify_survey_template_id" {
+  name = "/parks-reso-api/gc-notify-survey-template-id"
+}
+
 data "aws_ssm_parameter" "gc_notify_is_sending_reminders" {
   name = "/parks-reso-api/gc-notify-is-sending-reminders"
+}
+
+data "aws_ssm_parameter" "gc_notify_is_sending_surveys" {
+  name = "/parks-reso-api/gc-notify-is-sending-surveys"
+}
+
+data "aws_ssm_parameter" "feedback_survey_url" {
+  name = "/parks-reso-api/feedback-survey-url"
 }
 
 data "aws_ssm_parameter" "gc_notify_cancel_template_id" {

--- a/terraform/src/surveyJob.tf
+++ b/terraform/src/surveyJob.tf
@@ -1,0 +1,55 @@
+resource "aws_lambda_function" "send_survey_cronjob_target" {
+  function_name = "sendSurvey"
+
+  filename         = "artifacts/sendSurvey.zip"
+  source_code_hash = filebase64sha256("artifacts/sendSurvey.zip")
+
+  handler = "lambda/sendSurvey/index.handler"
+  runtime = "nodejs14.x"
+  timeout = 300
+  publish = "true"
+
+  environment {
+    variables = {
+      TABLE_NAME                     = data.aws_ssm_parameter.db_name.value,
+      META_TABLE_NAME                = data.aws_ssm_parameter.meta_db_name.value,
+      PASS_SHORTDATE_INDEX           = data.aws_ssm_parameter.pass_shortdate_index.value, 
+      GC_NOTIFY_API_BULK_PATH        = data.aws_ssm_parameter.gc_notify_api_bulk_path.value, 
+      GC_NOTIFY_API_KEY              = data.aws_ssm_parameter.gc_notify_api_key.value, 
+      GC_NOTIFY_SURVEY_TEMPLATE_ID   = data.aws_ssm_parameter.gc_notify_survey_template_id.value, 
+      GC_NOTIFY_IS_SENDING_SURVEYS   = data.aws_ssm_parameter.gc_notify_is_sending_surveys.value,
+      FEEDBACK_SURVEY_URL            = data.aws_ssm_parameter.feedback_survey_url.value,
+      RC_ALERT_WEBHOOK_URL           = data.aws_ssm_parameter.rc_alert_webhook_url.value,
+      RC_ALERT_WEBHOOK_TOKEN         = data.aws_ssm_parameter.rc_alert_webhook_token.value,
+      LOG_LEVEL                      = "info"
+    }
+  }
+  role = aws_iam_role.metaWriteRole.arn
+}
+
+resource "aws_lambda_alias" "send_survey_cronjob_target_latest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.send_survey_cronjob_target.function_name
+  function_version = aws_lambda_function.send_survey_cronjob_target.version
+}
+
+# Every day at 20:00 UTC (12:00 or 13:00 PDT/PST) = cron(0 0 * * ? *)
+resource "aws_cloudwatch_event_rule" "send_survey_cronjob_target_cronjob" {
+  name                = "send_survey_cronjob_target_cronjob"
+  description         = "Sends scheduled pass reminder at 16:00 PST/17:00 PDT"
+  schedule_expression = "cron(0 20 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "send_survey_cronjob_target_cronjob_target" {
+  rule      = aws_cloudwatch_event_rule.send_survey_cronjob_target_cronjob.name
+  target_id = "send_survey_cronjob_target"
+  arn       = aws_lambda_function.send_survey_cronjob_target.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_send_survey_cronjob_target" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.send_survey_cronjob_target.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.send_survey_cronjob_target_cronjob.arn
+}


### PR DESCRIPTION
### Jira Ticket:

BRS-934

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-934
### Description:

This change adds the survey email feature to DUP. The service is toggled by AWS Parameter `GC_NOTIFY_IS_SENDING_SURVEYS='true'`.

Other AWS Parameters to include:
```
GC_NOTIFY_SURVEY_TEMPLATE_ID
FEEDBACK_SURVEY_URL
```

This change reuses a considerable amount of code from the `sendReminder` email service. It runs on a cronjob that fires at 1200 PST (1300 PDT), collects all expired passes from the previous day (currently hardcoded to do this only for Mt. Seymour), and leverages GCN's Bulk Email API to deliver the surveys.

