### PR TITLE
BRS-1020 - new metrics API

### DIFF
--- a/__tests__/global/settings.js
+++ b/__tests__/global/settings.js
@@ -1,9 +1,11 @@
 const REGION = process.env.AWS_REGION || 'local-env';
 const ENDPOINT = 'http://localhost:8000';
 const TABLE_NAME = process.env.TABLE_NAME || 'parksreso-tests';
+const TIMEZONE = 'America/Vancouver';
 
 module.exports = {
   REGION,
   ENDPOINT,
-  TABLE_NAME
+  TABLE_NAME,
+  TIMEZONE
 };

--- a/__tests__/metrics.test.js
+++ b/__tests__/metrics.test.js
@@ -1,0 +1,499 @@
+const AWS = require('aws-sdk');
+const { DocumentClient } = require('aws-sdk/clients/dynamodb');
+const { REGION, ENDPOINT, TABLE_NAME, TIMEZONE } = require('./global/settings');
+const jwt = require('jsonwebtoken');
+const { DateTime } = require('luxon');
+const ALGORITHM = process.env.ALGORITHM || "HS384";
+
+const today = DateTime.now().setZone(TIMEZONE);
+const tomorrow = today.plus({ days: 1 });
+const yesterday = today.minus({ days: 1 });
+
+const ddb = new DocumentClient({
+  region: REGION,
+  endpoint: ENDPOINT,
+  convertEmptyValues: true
+});
+
+const mockedSysadmin = {
+  decodeJWT: jest.fn((event) => {
+    // console.log("STUB");
+  }),
+  resolvePermissions: jest.fn((token) => {
+    return {
+      isAdmin: true,
+      roles: ['sysadmin'],
+      isAuthenticated: true,
+    }
+  }),
+  getParkAccess: jest.fn((orcs, permissionObject) => {
+    return;
+  })
+};
+
+const mockedRoleBasedUser = {
+  decodeJWT: jest.fn((event) => {
+    // console.log("STUB");
+  }),
+  resolvePermissions: jest.fn((token) => {
+    return {
+      isAdmin: false,
+      roles: ['someparkrole'],
+      isAuthenticated: true
+    }
+  }),
+  getParkAccess: jest.fn((orcs, permissionObject) => {
+    return {};
+  })
+};
+
+const mockPark = {
+  pk: 'park',
+  sk: 'Test Park',
+  name: 'Test Park',
+  description: '<p>My Description</p>',
+  bcParksLink: 'http://google.ca',
+  mapLink: 'https://maps.google.com',
+  status: 'open',
+  visible: true
+}
+
+const mockFacility = {
+  pk: 'facility::Test Park',
+  sk: 'Test Facility',
+  name: 'Test Facility',
+  description: 'A Parking Lot!',
+  isUpdating: false,
+  type: "Parking",
+  bookingTimes: {
+    DAY: {
+      max: 3
+    }
+  },
+  bookingDays: {
+    "Sunday": true,
+    "Monday": true,
+    "Tuesday": true,
+    "Wednesday": true,
+    "Thursday": true,
+    "Friday": true,
+    "Saturday": true
+  },
+  bookingDaysRichText: '',
+  bookableHolidays: [],
+  status: { stateReason: '', state: 'open' },
+  qrcode: true,
+  visible: true
+}
+
+const token = jwt.sign({ foo: 'bar' }, 'shhhhh', { algorithm: ALGORITHM });
+
+describe('Read Metrics General', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV }; // Make a copy of environment
+  });
+
+  afterEach(async () => {
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  test('Unauthorized', async () => {
+    const readMetricsHandler = require('../lambda/readMetrics/index');
+    const event = {
+      headers: {
+        Authorization: 'Bearer ' + token + 'invalid'
+      },
+      httpMethod: 'GET'
+    };
+    expect(await readMetricsHandler.handler(event, null)).toMatchObject({
+      body: '{"msg":"Unauthorized"}',
+      statusCode: 403,
+    })
+  });
+
+  test('Missing query parameters', async () => {
+    jest.mock('../lambda/permissionUtil', () => {
+      return mockedSysadmin;
+    });
+    const readMetricsHandler = require('../lambda/readMetrics/index');
+    const event = {
+      headers: {
+        Authorization: 'Bearer ' + token
+      },
+      httpMethod: 'GET'
+    };
+    expect(await readMetricsHandler.handler(event, null)).toMatchObject({
+      body: '{"msg":"Invalid Request: Missing query parameters."}',
+      statusCode: 400,
+    })
+  })
+
+  test('Specific park authentication - user does not have specific park', async () => {
+    jest.mock('../lambda/permissionUtil', () => {
+      return mockedRoleBasedUser;
+    });
+    const readMetricsHandler = require('../lambda/readMetrics/index');
+    const event = {
+      headers: {
+        Authorization: 'Bearer ' + token
+      },
+      queryStringParameters: {
+        park: '0015',
+        facility: 'P1 and Lower P5',
+        startDate: '2023-03-27'
+      },
+      httpMethod: 'GET'
+    };
+    expect(await readMetricsHandler.handler(event, null)).toMatchObject({
+      body: '{"msg":"Unauthorized - user does not have the specific park role."}',
+      statusCode: 403,
+    })
+  })
+
+  test('Invalid dates', async () => {
+    jest.mock('../lambda/permissionUtil', () => {
+      return mockedSysadmin;
+    });
+    const readMetricsHandler = require('../lambda/readMetrics/index');
+    const event = {
+      headers: {
+        Authorization: 'Bearer ' + token
+      },
+      queryStringParameters: {
+        park: '0015',
+        facility: 'P1 and Lower P5',
+      },
+      httpMethod: 'GET'
+    };
+    Object.assign(event.queryStringParameters, { startDate: 'invalid' })
+    expect(await readMetricsHandler.handler(event, null)).toMatchObject({
+      body: '{"msg":"Invalid or malformed dates.","title":"Invalid dates","error":"Start date (invalid) is invalid."}',
+      statusCode: 400,
+    });
+    Object.assign(event.queryStringParameters, { startDate: '2023-01-03', endDate: 'invalid' })
+    expect(await readMetricsHandler.handler(event, null)).toMatchObject({
+      body: '{"msg":"Invalid or malformed dates.","title":"Invalid dates","error":"End date (invalid) is invalid."}',
+      statusCode: 400,
+    });
+    Object.assign(event.queryStringParameters, { startDate: '2023-01-03', endDate: '2023-01-02' })
+    expect(await readMetricsHandler.handler(event, null)).toMatchObject({
+      body: '{"msg":"Invalid or malformed dates.","title":"Invalid dates","error":"End date (2023-01-02) must be greater than or equal to the start date (2023-01-03)"}',
+      statusCode: 400,
+    });
+  })
+
+  test('Valid response', async () => {
+    jest.mock('../lambda/permissionUtil', () => {
+      return mockedSysadmin;
+    });
+    // no such thing as metrics table in test
+    process.env.METRICS_TABLE_NAME = TABLE_NAME;
+    const readMetricsHandler = require('../lambda/readMetrics/index');
+    const event = {
+      headers: {
+        Authorization: 'Bearer ' + token
+      },
+      queryStringParameters: {
+        park: 'MOCK',
+        facility: 'Mock Facility',
+        startDate: '2023-01-01',
+      },
+      httpMethod: 'GET'
+    };
+    const res = await readMetricsHandler.handler(event, null);
+    expect(res.statusCode).toEqual(200);
+  });
+})
+
+let newMetricsList = [];
+describe('Metrics utils general', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV }; // Make a copy of environment
+    await databaseOperation(1, 'setup');
+  });
+
+  afterEach(async () => {
+    await databaseOperation(1, 'teardown');
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  test('Create metric - today - simple', async () => {
+    const { createMetric } = require('../lambda/metricsUtils');
+    const res = await createMetric(mockPark, mockFacility, today.toISODate());
+    expect(res.sk).toEqual(today.toISODate());
+    expect(res.cancelled).toEqual(0);
+    expect(res.totalPasses).toEqual(1);
+    expect(res.fullyBooked).toEqual(false);
+    expect(res.capacities.DAY).toEqual({
+      baseCapacity: 3,
+      capacityModifier: 0,
+      availablePasses: 2,
+      overbooked: 0,
+      checkedIn: 1,
+      passStatuses: {
+        active: 1
+      }
+    });
+    newMetricsList.push(res);
+  })
+
+  test('Create metric - tomorrow, fully booked, 1 overbooked', async () => {
+    const { createMetric } = require('../lambda/metricsUtils');
+    const res = await createMetric(mockPark, mockFacility, tomorrow.toISODate());
+    expect(res.sk).toEqual(tomorrow.toISODate());
+    expect(res.cancelled).toEqual(0);
+    expect(res.totalPasses).toEqual(5);
+    expect(res.fullyBooked).toEqual(true);
+    expect(res.capacities.DAY).toEqual({
+      baseCapacity: 3,
+      capacityModifier: 1,
+      availablePasses: 0,
+      overbooked: 1,
+      checkedIn: 0,
+      passStatuses: {
+        reserved: 5
+      }
+    });
+    newMetricsList.push(res);
+  })
+
+  test('Create metric - yesterday, 1 cancellation, 1 expired', async () => {
+    const { createMetric } = require('../lambda/metricsUtils');
+    const res = await createMetric(mockPark, mockFacility, yesterday.toISODate());
+    expect(res.sk).toEqual(yesterday.toISODate());
+    expect(res.cancelled).toEqual(1);
+    expect(res.totalPasses).toEqual(1);
+    expect(res.fullyBooked).toEqual(false);
+    expect(res.capacities.DAY).toEqual({
+      baseCapacity: 3,
+      capacityModifier: 0,
+      availablePasses: 2,
+      overbooked: 0,
+      checkedIn: 1,
+      passStatuses: {
+        expired: 1, cancelled: 1
+      }
+    });
+    newMetricsList.push(res);
+  })
+
+})
+
+// create new describe to ensure it runs after the previous describe block
+describe('Metrics post', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV }; // Make a copy of environment
+    // be cheeky and store the stuff in the same table instead of a new one
+    process.env.METRICS_TABLE_NAME = TABLE_NAME;
+    await databaseOperation(1, 'setup');
+  });
+
+  afterEach(async () => {
+    await databaseOperation(1, 'teardown');
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV; // Restore old environment
+  });
+
+  test('Post all metrics', async () => {
+    const { postAllMetrics } = require('../lambda/metricsUtils');
+    const res = await postAllMetrics(newMetricsList);
+    // Three new metrics were created
+    expect(res).toEqual(3);
+    const dates = [today, tomorrow, yesterday];
+    for (const date of dates) {
+      const check = await ddb.get({
+        TableName: TABLE_NAME,
+        Key: {
+          pk: `metrics::Test Park::Test Facility`,
+          sk: date.toISODate()
+        }
+      }).promise();
+      // expect metric item to exist in db
+      expect(check.Item).toBeTruthy();
+    }
+  })
+})
+
+async function databaseOperation(version, mode) {
+  if (version === 1) {
+    if (mode === 'setup') {
+      await ddb.put({
+        TableName: TABLE_NAME,
+        Item: mockPark
+      }).promise();
+
+      await ddb.put({
+        TableName: TABLE_NAME,
+        Item: mockFacility
+      }).promise();
+
+      await ddb.put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'reservations::Test Park::Test Facility',
+          sk: today.toISODate(),
+          capacities: {
+            DAY: {
+              baseCapacity: 3,
+              capacityModifier: 0,
+              availablePasses: 2,
+              overbooked: 0
+            }
+          }
+        }
+      }).promise();
+
+      await ddb.put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'reservations::Test Park::Test Facility',
+          sk: tomorrow.toISODate(),
+          capacities: {
+            DAY: {
+              baseCapacity: 3,
+              capacityModifier: 1,
+              availablePasses: 0,
+              overbooked: 1
+            }
+          }
+        }
+      }).promise();
+
+      await ddb.put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'reservations::Test Park::Test Facility',
+          sk: yesterday.toISODate(),
+          capacities: {
+            DAY: {
+              baseCapacity: 3,
+              capacityModifier: 0,
+              availablePasses: 2,
+              overbooked: 0
+            }
+          }
+        }
+      }).promise();
+
+      await ddb.put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: '1',
+          checkedIn: true,
+          checkedInTime: today.toISO(),
+          passStatus: 'active',
+          shortPassDate: today.toISODate(),
+          facilityName: 'Test Facility',
+          numberOfGuests: 1,
+          type: 'DAY'
+        }
+      }).promise();
+
+      await ddb.put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: '2',
+          checkedIn: false,
+          passStatus: 'reserved',
+          shortPassDate: tomorrow.toISODate(),
+          facilityName: 'Test Facility',
+          numberOfGuests: 4,
+          type: 'DAY'
+        }
+      }).promise();
+
+      await ddb.put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: '3',
+          checkedIn: false,
+          passStatus: 'reserved',
+          shortPassDate: tomorrow.toISODate(),
+          facilityName: 'Test Facility',
+          numberOfGuests: 1,
+          type: 'DAY',
+          isOverbooked: true
+        }
+      }).promise();
+
+      await ddb.put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: '4',
+          checkedIn: true,
+          checkedInTime: yesterday.toISO(),
+          passStatus: 'expired',
+          shortPassDate: yesterday.toISODate(),
+          facilityName: 'Test Facility',
+          numberOfGuests: 1,
+          type: 'DAY',
+        }
+      }).promise();
+
+      await ddb.put({
+        TableName: TABLE_NAME,
+        Item: {
+          pk: 'pass::Test Park',
+          sk: '5',
+          passStatus: 'cancelled',
+          shortPassDate: yesterday.toISODate(),
+          facilityName: 'Test Facility',
+          numberOfGuests: 1,
+          type: 'DAY',
+        }
+      }).promise();
+
+    } else {
+      // Teardown
+
+      const pkskList = [
+        { pk: 'park', sk: 'Test Park' },
+        { pk: 'facility::Test Park', sk: 'Test Facility' },
+        { pk: 'reservations::Test Park::Test Facility', sk: today.toISODate() },
+        { pk: 'reservations::Test Park::Test Facility', sk: tomorrow.toISODate() },
+        { pk: 'reservations::Test Park::Test Facility', sk: yesterday.toISODate() },
+        { pk: 'pass::Test Park', sk: '1' },
+        { pk: 'pass::Test Park', sk: '2' },
+        { pk: 'pass::Test Park', sk: '3' },
+        { pk: 'pass::Test Park', sk: '4' },
+        { pk: 'pass::Test Park', sk: '5' },
+        { pk: 'metrics::Test Park::Test Facility', sk: today.toISODate() },
+        { pk: 'metrics::Test Park::Test Facility', sk: tomorrow.toISODate() },
+        { pk: 'metrics::Test Park::Test Facility', sk: yesterday.toISODate() },
+      ]
+
+      for (const item of pkskList) {
+        await ddb
+          .delete({
+            TableName: TABLE_NAME,
+            Key: {
+              pk: item.pk,
+              sk: item.sk
+            }
+          })
+          .promise();
+      }
+    }
+  }
+}

--- a/lambda/dynamoUtil.js
+++ b/lambda/dynamoUtil.js
@@ -4,6 +4,7 @@ const { DateTime } = require('luxon');
 
 const TABLE_NAME = process.env.TABLE_NAME || 'parksreso';
 const META_TABLE_NAME = process.env.META_TABLE_NAME || 'parksreso-meta';
+const METRICS_TABLE_NAME = process.env.METRICS_TABLE_NAME || 'parksreso-metrics';
 const options = {
   region: 'ca-central-1'
 };
@@ -79,7 +80,7 @@ async function getOne(pk, sk) {
   logger.info(`getItem: { pk: ${pk}, sk: ${sk} }`);
   const params = {
     TableName: TABLE_NAME,
-    Key: AWS.DynamoDB.Converter.marshall({pk, sk})
+    Key: AWS.DynamoDB.Converter.marshall({ pk, sk })
   };
   let item = await dynamodb.getItem(params).promise();
   return item?.Item || {};
@@ -185,7 +186,7 @@ async function getParks() {
 
 // get a single facility by park name & facility sk.
 // if not authenticated, invisible facilities will not be returned.
-async function getFacility(parkSk, sk, authenticated = false){
+async function getFacility(parkSk, sk, authenticated = false) {
   const facility = await getOne(`facility::${parkSk}`, sk);
   if (!authenticated && !facility.visible.BOOL) {
     return {};
@@ -272,6 +273,7 @@ module.exports = {
   TIMEZONE,
   TABLE_NAME,
   META_TABLE_NAME,
+  METRICS_TABLE_NAME,
   dynamodb,
   setStatus,
   runQuery,

--- a/lambda/metricsUtils.js
+++ b/lambda/metricsUtils.js
@@ -1,0 +1,195 @@
+const AWS = require('aws-sdk');
+const { DateTime } = require("luxon");
+const { METRICS_TABLE_NAME, TABLE_NAME, TIMEZONE, runQuery, dynamodb, getOne } = require("./dynamoUtil");
+const { logger } = require("./logger");
+
+const MAX_TRANSACTION_SIZE = 25;
+
+async function createMetric(park, facility, date) {
+  const today = DateTime.now().setZone(TIMEZONE);
+  const currentDate = today.toISODate();
+
+  let capacities = {};
+  // Get passes for park/facility/date DB:
+  let hourlyData = [];
+  const [passes, resObj] = await Promise.all([getPassesForDate(facility, date), getReservationObjectForDate(park.sk, facility.sk, date)]);
+
+  for (const time in facility.bookingTimes) {
+    capacities[time] = {
+      baseCapacity: resObj?.capacities?.[time].baseCapacity ??
+        (facility.bookingTimes[time].max || 0),
+      capacityModifier: resObj?.capacities?.[time].capacityModifier || 0,
+      availablePasses: resObj?.capacities?.[time].availablePasses ??
+        (facility?.bookingTimes?.[time]?.max || 0),
+      overbooked: resObj?.capacities?.[time].overbooked || 0,
+      checkedIn: 0,
+      passStatuses: {}
+    }
+  }
+
+  if (date <= currentDate) {
+    // create 24h of hourly data object
+    for (let hour = 0; hour <= 23; hour++) {
+      hourlyData.push({
+        hour: hour,
+        checkedIn: 0,
+      })
+    }
+  }
+
+  if (passes.length) {
+    for (const pass of passes) {
+      if (Object.keys(capacities).indexOf(pass.type) === -1) {
+        // The pass belongs to a timeslot that no longer exists.
+        capacities[pass.type] = {
+          slotDeleted: true,
+          baseCapacity: 0,
+          capacityModifier: 0,
+          availablePasses: 0,
+          overbooked: 0,
+          passStatuses: {}
+        }
+      }
+      if (capacities[pass.type].slotDeleted) {
+        // If timeslot doesn't exist, count pass as overbooked
+        capacities[pass.type].overbooked += pass.numberOfGuests;
+      }
+      if (pass.checkedIn) {
+        // Increase total checked in counter
+        capacities[pass.type].checkedIn += pass.numberOfGuests;
+      }
+      if (pass.passStatus) {
+        if (!capacities[pass.type].passStatuses[pass.passStatus]) {
+          capacities[pass.type].passStatuses[pass.passStatus] = 0;
+        }
+        capacities[pass.type].passStatuses[pass.passStatus] += pass.numberOfGuests
+      }
+      // collect hourly data 
+      if (pass.checkedInTime && hourlyData.length) {
+        const checkInHour = DateTime.fromISO(pass.checkedInTime).get('hour');
+        // hourlyData index === 0-23 hour
+        hourlyData[checkInHour]['checkedIn'] += pass.numberOfGuests;
+      }
+    }
+  }
+
+  // Get total pass count:
+  let totalUsedPasses = 0;
+  let totalCancelledPasses = 0;
+  let totalCapacity = 0;
+
+  for (const time in capacities) {
+    totalCapacity += capacities[time].baseCapacity;
+    totalCapacity += capacities[time].capacityModifier;
+    totalUsedPasses += capacities[time].passStatuses['active'] || 0;
+    totalUsedPasses += capacities[time].passStatuses['reserved'] || 0;
+    totalUsedPasses += capacities[time].passStatuses['expired'] || 0;
+    totalCancelledPasses += capacities[time].passStatuses['cancelled'] || 0;
+  }
+
+  let metricsObj = {
+    pk: `metrics::${park.sk}::${facility.sk}`,
+    sk: date,
+    lastUpdated: today.toISO(),
+    totalPasses: totalUsedPasses,
+    cancelled: totalCancelledPasses,
+    fullyBooked: totalUsedPasses >= totalCapacity ? true : false,
+    capacities: capacities
+  }
+
+  if (hourlyData.length) {
+    metricsObj['hourlyData'] = hourlyData;
+  }
+
+  return metricsObj;
+}
+
+async function postAllMetrics(metrics) {
+  // Use AWS TransactWrite as the number of metrics objects could be quite large.
+  // The incoming metrics object should not contain collisions, so TransactWrite ok.
+  // We will be overwriting existing metrics objects of the same primary key to keep things up to date.
+
+  // Create the transactions
+  let transactions = [];
+  let errors = [];
+  let successes = 0;
+  try {
+    for (let i = 0; i < metrics.length; i += MAX_TRANSACTION_SIZE) {
+      let transactionChunk = { TransactItems: [] };
+      const metricsChunk = metrics.slice(i, i + MAX_TRANSACTION_SIZE);
+      for (const metric of metricsChunk) {
+        try {
+          let metricsPutObj = {
+            TableName: METRICS_TABLE_NAME,
+            Item: AWS.DynamoDB.Converter.marshall(metric)
+          }
+          transactionChunk.TransactItems.push({
+            Put: metricsPutObj
+          });
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      transactions.push(transactionChunk);
+    }
+    logger.info('Metrics transactions created.');
+  } catch (error) {
+    logger.error(error);
+  }
+
+  // Execute the transactions
+  try {
+    for (const transaction of transactions) {
+      try {
+        await dynamodb.transactWriteItems(transaction).promise();
+        successes += transaction.TransactItems.length;
+      } catch (error) {
+        errors.push(error);
+        logger.error(error);
+      }
+    }
+    logger.info('Metrics items written to database.');
+  } catch (error) {
+    logger.error(error);
+  }
+
+  if (errors.length) {
+    logger.error(errors);
+  }
+  logger.info('Successes:', successes);
+  return successes;
+}
+
+async function getPassesForDate(facility, date) {
+  try {
+    const passQueryObj = {
+      TableName: TABLE_NAME,
+      IndexName: 'manualLookup-index',
+      KeyConditionExpression: 'shortPassDate = :shortPassDate AND facilityName = :facilityName',
+      ExpressionAttributeValues: {
+        ':shortPassDate': { S: date },
+        ':facilityName': { S: facility.sk }
+      }
+    }
+    const passes = await runQuery(passQueryObj, false);
+    return passes;
+  } catch (error) {
+    logger.error(`Error retrieving passes for ${facility?.facilityName}: ${error}`);
+    return;
+  }
+}
+
+async function getReservationObjectForDate(parkSk, facilitySk, date) {
+  try {
+    const reservation = await getOne(`reservations::${parkSk}::${facilitySk}`, date);
+    return AWS.DynamoDB.Converter.unmarshall(reservation);
+  } catch (error) {
+    logger.error(`Error retrieving reservation object for ${facilitySk}: ${error}`);
+    return;
+  }
+}
+
+module.exports = {
+  createMetric,
+  postAllMetrics
+}

--- a/lambda/readMetrics/index.js
+++ b/lambda/readMetrics/index.js
@@ -1,0 +1,82 @@
+const { METRICS_TABLE_NAME, runQuery } = require("../dynamoUtil");
+const { logger } = require("../logger");
+const { decodeJWT, resolvePermissions } = require("../permissionUtil");
+const { sendResponse } = require("../responseUtil");
+const { DateTime } = require('luxon');
+
+exports.handler = async (event, context) => {
+
+  if (!event || !event.headers) {
+    logger.info('Unauthorized');
+    return sendResponse(403, { msg: 'Unauthorized' }, context);
+  }
+
+  logger.debug('Fetching metrics for selected date range');
+
+  // 1. Get the relevant metrics information from the queryparameters
+
+  try {
+    const token = await decodeJWT(event);
+    const permissionObject = resolvePermissions(token);
+
+    if (permissionObject.isAuthenticated !== true) {
+      logger.info('Unauthorized');
+      return sendResponse(403, { msg: 'Unauthorized' }, context);
+    }
+
+    if (!event.queryStringParameters ||
+      !event.queryStringParameters.park ||
+      !event.queryStringParameters.facility ||
+      !event.queryStringParameters.startDate) {
+      logger.info('Invalid Request');
+      return sendResponse(400, { msg: 'Invalid Request: Missing query parameters.' });
+    }
+
+
+    const park = event.queryStringParameters.park
+    const facility = event.queryStringParameters.facility
+    const startDate = event.queryStringParameters.startDate
+    const endDate = event.queryStringParameters.endDate || startDate;
+
+    // check if user has correct role
+    if (!permissionObject.isAdmin && permissionObject.roles.indexOf(park) === -1) {
+      logger.info('Unauthorized - user does not have the specific park role.');
+      return sendResponse(403, { msg: 'Unauthorized - user does not have the specific park role.' });
+    }
+
+    // vali-date (haha get it?)
+    try {
+      if (!DateTime.fromISO(startDate).isValid) {
+        throw `Start date (${startDate}) is invalid.`;
+      }
+      if (!DateTime.fromISO(endDate).isValid) {
+        throw `End date (${endDate}) is invalid.`;
+      }
+      if (startDate > endDate) {
+        throw `End date (${endDate}) must be greater than or equal to the start date (${startDate})`;
+      }
+    } catch (error) {
+      logger.info('Invalid dates.');
+      return sendResponse(400, { msg: 'Invalid or malformed dates.', title: 'Invalid dates', error: error });
+    }
+
+    // 2. Query DB for metrics for the park/facility within the date range.
+    const metricsQueryObj = {
+      TableName: METRICS_TABLE_NAME,
+      KeyConditionExpression: `pk = :pk AND sk BETWEEN :startDate AND :endDate`,
+      ExpressionAttributeValues: {
+        ':pk': { S: `metrics::${park}::${facility}` },
+        ':startDate': { S: startDate },
+        ':endDate': { S: endDate },
+      }
+    }
+
+    const res = await runQuery(metricsQueryObj);
+    return sendResponse(200, res);
+
+  } catch (error) {
+    logger.error(error);
+    return sendResponse(400, { msg: 'Something went wrong.', title: 'Operation failed.', error: error })
+  }
+
+}

--- a/lambda/writeMetrics/index.js
+++ b/lambda/writeMetrics/index.js
@@ -1,0 +1,65 @@
+const { DateTime } = require("luxon");
+const { getParks, getFacilities, TIMEZONE} = require("../dynamoUtil");
+const { logger } = require("../logger");
+const { createMetric, postAllMetrics } = require("../metricsUtils");
+const { getFutureReservationObjects } = require('../reservationObjUtils');
+const { sendResponse } = require("../responseUtil");
+
+const today = DateTime.now().setZone(TIMEZONE);
+
+exports.handler = async (event, context) => {
+  logger.debug('Running metrics collection service');
+
+  try {
+    const metrics = await createAllMetrics();
+    await postAllMetrics(metrics);
+    logger.info('Metrics collection complete.');
+    return sendResponse(200, { msg: `Metrics updated.`, title: 'Operation successful.' });
+  } catch (error) {
+    logger.error(error);
+    return sendResponse(400, { msg: `Something went wrong collecting metrics data.`, title: 'Operation failed.', error: error })
+  }
+}
+
+async function createAllMetrics() {
+  // For each subarea, get up-to-date metrics
+  let metricsObj = [];
+  try {
+    // We need to get a list of all dates into the future starting from today that have data.
+    // We can do this by getting a list of all the future reservations Objects for each park and extracting the date.
+    // If there are no reservation objects, we can assume theres nothing to track. 
+    const parks = await getParks();
+    for (const park of parks) {
+      const facilities = await getFacilities(park.sk);
+      for (const facility of facilities) {
+        // Get future reservation objects for that park/facility
+        const futureResObjs = await getFutureReservationObjects(park.sk, facility.name);
+        let todayFlag = false;
+        if (futureResObjs) {
+          for (const date of futureResObjs) {
+            // Create a metrics item for each future date
+            if (date.sk === today.toISODate()) {
+              // We have a reservationObject for today
+              todayFlag = true;
+            }
+            const futureResMetric = await createMetric(park, facility, date.sk);
+            metricsObj.push(futureResMetric);
+          }
+        }
+        if (!todayFlag) {
+          // We need to update today's metrics object no matter what
+          const todayMetric = await createMetric(park, facility, today.toISODate());
+          metricsObj.push(todayMetric);
+        }
+      }
+    }
+
+    logger.debug('Metrics object:', metricsObj);
+    logger.info(`Metrics object (${metricsObj.length} items) successfully created.`)
+    return metricsObj;
+  } catch (error) {
+    throw error;
+  }
+}
+
+

--- a/serverless.yml
+++ b/serverless.yml
@@ -188,7 +188,7 @@ functions:
           cors: true
 
   ###########
-  # Metric
+  # Metric TODO -delete
   ###########
   metric:
     handler: lambda/metric/index.handler
@@ -196,6 +196,17 @@ functions:
       - http:
           method: GET
           path: /metric
+          cors: true
+
+  ###########
+  # Metrics
+  ###########
+  readMetrics:
+    handler: lambda/readMetrics/index.handler
+    events:
+      - http:
+          method: GET
+          path: /metrics
           cors: true
 
   ###########
@@ -218,6 +229,10 @@ functions:
   # aws lambda invoke /dev/null --endpoint-url http://localhost:3002 --function-name parks-reso-api-api-sendSurvey
   sendSurvey:
     handler: lambda/sendSurvey/index.handler
+  # aws lambda invoke /dev/null --endpoint-url http://localhost:3002 --function-name parks-reso-api-api-writeMetrics
+  writeMetrics:
+    handler: lambda/writeMetrics/index.handler
+
 
 custom:
   dynamodb:

--- a/terraform/src/db.tf
+++ b/terraform/src/db.tf
@@ -114,6 +114,31 @@ resource "aws_dynamodb_table" "park_dup_meta_table" {
   }
 }
 
+resource "aws_dynamodb_table" "park_dup_metrics_table" {
+  name           = "${data.aws_ssm_parameter.metrics_db_name.value}${var.env_identifier}"
+  hash_key       = "pk"
+  range_key      = "sk"
+  billing_mode   = "PAY_PER_REQUEST"
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = {
+    Name = "Database"
+  }
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+}
+
 resource "aws_backup_vault" "parksreso_backup_vault" {
   name        = "backup_vault_for_parksreso${var.env_identifier}"
 }

--- a/terraform/src/main.tf
+++ b/terraform/src/main.tf
@@ -177,7 +177,8 @@ resource "aws_api_gateway_deployment" "apideploy" {
     aws_api_gateway_integration.captchaVerifyIntegration,
     aws_api_gateway_integration.captchaAudioIntegration,
     aws_api_gateway_integration.readReservationIntegration,
-    aws_api_gateway_integration.putModifierIntegration
+    aws_api_gateway_integration.putModifierIntegration,
+    aws_api_gateway_integration.metricsIntegration
   ]
 
   rest_api_id = aws_api_gateway_rest_api.apiLambda.id
@@ -318,8 +319,14 @@ resource "aws_iam_role_policy_attachment" "lambda_sendReminder_cloudwatch_logs" 
   policy_arn = aws_iam_policy.lambda_logging.arn
 }
 
+// TODO - remove metric
 resource "aws_iam_role_policy_attachment" "lambda_metric_cloudwatch_logs" {
   role       = aws_iam_role.metricRole.name
+  policy_arn = aws_iam_policy.lambda_logging.arn
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_metrics_cloudwatch_logs" {
+  role       = aws_iam_role.metricsRole.name
   policy_arn = aws_iam_policy.lambda_logging.arn
 }
 

--- a/terraform/src/metric.tf
+++ b/terraform/src/metric.tf
@@ -1,3 +1,4 @@
+// TODO - remove metric
 resource "aws_lambda_function" "metricLambda" {
   function_name = "metric${var.env_identifier}"
 

--- a/terraform/src/metrics.tf
+++ b/terraform/src/metrics.tf
@@ -1,0 +1,110 @@
+resource "aws_lambda_function" "metricsLambda" {
+  function_name = "readMetrics${var.env_identifier}"
+
+  filename         = "artifacts/readMetrics.zip"
+  source_code_hash = filebase64sha256("artifacts/readMetrics.zip")
+
+  handler = "lambda/readMetrics/index.handler"
+  runtime = "nodejs14.x"
+  timeout = 6
+  publish = "true"
+
+  memory_size = 768
+
+  environment {
+    variables = {
+      METRICS_TABLE_NAME  = data.aws_ssm_parameter.metrics_db_name.value,
+      LOG_LEVEL   = "info"
+    }
+  }
+
+   role = aws_iam_role.metricsRole.arn
+}
+
+resource "aws_lambda_alias" "metricsLambdaLatest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.metricsLambda.function_name
+  function_version = aws_lambda_function.metricsLambda.version
+}
+
+resource "aws_api_gateway_resource" "metricsResource" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  parent_id   = aws_api_gateway_rest_api.apiLambda.root_resource_id
+  path_part   = "metrics"
+}
+
+// Defines the HTTP GET /metric API
+resource "aws_api_gateway_method" "metricsMethod" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = aws_api_gateway_resource.metricsResource.id
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+// Integrates the APIG to Lambda via POST method
+resource "aws_api_gateway_integration" "metricsIntegration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.metricsResource.id
+  http_method = aws_api_gateway_method.metricsMethod.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.metricsLambda.invoke_arn
+}
+
+resource "aws_lambda_permission" "metricsPermission" {
+  statement_id  = "AllowParksDayUsePassAPIInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.metricsLambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.apiLambda.execution_arn}/*/GET/metrics"
+}
+
+//CORS
+resource "aws_api_gateway_method" "metrics_options_method" {
+  rest_api_id   = aws_api_gateway_rest_api.apiLambda.id
+  resource_id   = aws_api_gateway_resource.metricsResource.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method_response" "metrics_options_200" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.metricsResource.id
+  http_method = aws_api_gateway_method.metrics_options_method.http_method
+  status_code = "200"
+  response_models = {
+    "application/json" = "Empty"
+  }
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true,
+    "method.response.header.Access-Control-Allow-Methods" = true,
+    "method.response.header.Access-Control-Allow-Origin"  = true
+  }
+  depends_on = [aws_api_gateway_method.metrics_options_method]
+}
+
+resource "aws_api_gateway_integration" "metrics_options_integration" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.metricsResource.id
+  http_method = aws_api_gateway_method.metrics_options_method.http_method
+  type        = "MOCK"
+  request_templates = {
+    "application/json" : "{\"statusCode\": 200}"
+  }
+  depends_on = [aws_api_gateway_method.metrics_options_method]
+}
+
+resource "aws_api_gateway_integration_response" "metrics_options_integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.apiLambda.id
+  resource_id = aws_api_gateway_resource.metricsResource.id
+  http_method = aws_api_gateway_method.metrics_options_method.http_method
+
+  status_code = aws_api_gateway_method_response.metrics_options_200.status_code
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+    "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS'",
+    "method.response.header.Access-Control-Allow-Origin"  = "'*'"
+  }
+  depends_on = [aws_api_gateway_method_response.metrics_options_200]
+}

--- a/terraform/src/metricsJob.tf
+++ b/terraform/src/metricsJob.tf
@@ -1,0 +1,47 @@
+resource "aws_lambda_function" "write_metrics" {
+  function_name = "writeMetrics${var.env_identifier}"
+
+  filename         = "artifacts/writeMetrics.zip"
+  source_code_hash = filebase64sha256("artifacts/writeMetrics.zip")
+
+  handler = "lambda/writeMetrics/index.handler"
+  runtime = "nodejs14.x"
+  timeout = 300
+  publish = "true"
+
+  environment {
+    variables = {
+      TABLE_NAME                     = data.aws_ssm_parameter.db_name.value,
+      METRICS_TABLE_NAME             = data.aws_ssm_parameter.metrics_db_name.value
+      LOG_LEVEL                      = "info"
+    }
+  }
+  role = aws_iam_role.metricsRole.arn
+}
+
+resource "aws_lambda_alias" "write_metrics_latest" {
+  name             = "latest"
+  function_name    = aws_lambda_function.write_metrics.function_name
+  function_version = aws_lambda_function.write_metrics.version
+}
+
+# Every 5 minutes (starting on the hour), run this. 
+resource "aws_cloudwatch_event_rule" "write_metrics_cronjob" {
+  name                = "write_metrics_cronjob${var.env_identifier}"
+  description         = "Gathers and updates metrics every 5 minutes, starting on the hour."
+  schedule_expression = "cron(0/5 * * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "write_metrics_cronjob_target" {
+  rule      = aws_cloudwatch_event_rule.write_metrics_cronjob.name
+  target_id = "write_metrics"
+  arn       = aws_lambda_function.write_metrics.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_write_metrics" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.write_metrics.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.write_metrics_cronjob.arn
+}

--- a/terraform/src/params.tf
+++ b/terraform/src/params.tf
@@ -6,6 +6,10 @@ data "aws_ssm_parameter" "meta_db_name" {
   name = "/parks-reso-api/meta-db-name"
 }
 
+data "aws_ssm_parameter" "metrics_db_name" {
+  name = "/parks-reso-api/metrics-db-name"
+}
+
 data "aws_ssm_parameter" "pass_shortdate_index" {
   name = "/parks-reso-api/pass-shortdate-index"
 }

--- a/terraform/src/roles.tf
+++ b/terraform/src/roles.tf
@@ -122,6 +122,7 @@ resource "aws_s3_bucket" "bcgov-parks-dup-data" {
   }
 }
 
+// TODO - remove metric
 resource "aws_iam_role" "metricRole" {
   name = "lambdaMetricRole${var.env_identifier}"
 
@@ -187,6 +188,27 @@ EOF
 
 resource "aws_iam_role" "metaWriteRole" {
   name = "lambdaMetaWriteRole${var.env_identifier}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role" "metricsRole" {
+  name = "lambdaMetricsRole${var.env_identifier}"
 
   assume_role_policy = <<EOF
 {
@@ -356,6 +378,7 @@ resource "aws_iam_role_policy" "exportAllPassRolePolicy" {
   EOF
 }
 
+// TODO - remove metric
 resource "aws_iam_role_policy" "park_reso_dynamodb_metric" {
   name = "park_reso_dynamodb_metric${var.env_identifier}"
   role = aws_iam_role.metricRole.id
@@ -487,6 +510,60 @@ resource "aws_iam_role_policy" "dynamoDBMetaWriteRole" {
         "Effect": "Allow",
         "Action": [
             "dynamodb:Query"
+        ],
+        "Resource": "${aws_dynamodb_table.park_dup_table.arn}/index/*"
+      }
+    ]
+  }
+  EOF
+}
+
+// Allow reading main table and read/writing to metrics table
+resource "aws_iam_role_policy" "dynamoDBMetricsWriteRole" {
+  name = "park_reso_dynamodb_metrics${var.env_identifier}"
+  role = aws_iam_role.metricsRole.id
+
+  policy = <<-EOF
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:BatchGet*",
+            "dynamodb:DescribeStream",
+            "dynamodb:DescribeTable",
+            "dynamodb:Get*",
+            "dynamodb:Query",
+            "dynamodb:Scan",
+            "dynamodb:CreateTable",
+            "dynamodb:ConditionCheckItem"
+        ],
+        "Resource": "${aws_dynamodb_table.park_dup_table.arn}"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:BatchGet*",
+            "dynamodb:DescribeStream",
+            "dynamodb:DescribeTable",
+            "dynamodb:Get*",
+            "dynamodb:Query",
+            "dynamodb:Scan",
+            "dynamodb:BatchWrite*",
+            "dynamodb:CreateTable",
+            "dynamodb:Delete*",
+            "dynamodb:Update*",
+            "dynamodb:PutItem",
+            "dynamodb:ConditionCheckItem"
+        ],
+        "Resource": "${aws_dynamodb_table.park_dup_metrics_table.arn}"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:Query",
+            "dynamodb:Get*",
         ],
         "Resource": "${aws_dynamodb_table.park_dup_table.arn}/index/*"
       }

--- a/tools/backfillMetrics.js
+++ b/tools/backfillMetrics.js
@@ -1,0 +1,86 @@
+// A short developer script to create metrics objects for past dates.
+// This script runs the metrics job manually for a set date range instead of looking at today & the future.
+// It will overwrite any items it collides with, same as the metrics job does.
+
+const { DateTime, Interval } = require('luxon');
+const { TIMEZONE, getParks, getFacilities } = require('../lambda/dynamoUtil');
+const { logger } = require('../lambda/logger');
+const { createMetric, postAllMetrics } = require('../lambda/metricsUtils');
+
+async function run() {
+  console.log('********************');
+  console.log('DUP METRICS BACKFILL\n');
+
+  let startDate;
+  let endDate;
+
+  try {
+    if (process.argv.length <= 3) {
+      console.log("Invalid parameters.");
+      console.log("");
+      console.log("Usage: node backfillMetrics.js <startDate> <endDate>");
+      console.log("");
+      console.log("Options");
+      console.log("    <startDate>: The beginning of the date range to backfill (format: YYYY-MM-DD in PST)");
+      console.log("    <endDate>: The end of the date range to backfill (format: YYYY-MM-DD in PST)");
+      console.log("");
+      console.log("example: node migrate.js 2021-11-30 2023-03-22");
+      console.log("");
+      return;
+    } else {
+      // Validate dates
+      startDate = process.argv[2];
+      endDate = process.argv[3];
+      if (startDate > endDate) {
+        throw `End date (${endDate}) must be greater than or equal to the start date (${startDate})`;
+      }
+
+    }
+
+    // Create array of dates from interval
+    const interval = Interval.fromDateTimes(
+      DateTime.fromISO(startDate).setZone(TIMEZONE).startOf('day'),
+      DateTime.fromISO(endDate).setZone(TIMEZONE).endOf('day')
+    ).splitBy({ day: 1 }).map(d => d.start.toISODate());
+
+    console.log(`Gathering metrics for ${interval.length} days.`);
+
+    // For each facility, create a metrics object on every date in interval.
+    let metricsObj = [];
+    try {
+      const parks = await getParks();
+      for (const park of parks) {
+        const facilities = await getFacilities(park.sk);
+        for (const facility of facilities) {
+          for (const date of interval) {
+            process.stdout.write(` Gathering metrics: ${metricsObj.length + 1}\r`);
+            const metric = await createMetric(park, facility, date);
+            metricsObj.push(metric);
+          }
+        }
+      }
+      process.stdout.write(`\n`);
+    } catch (error) {
+      // Error creating metrics objects
+      logger.error(error);
+    }
+
+    console.log(`Creating ${metricsObj.length} new metrics items.`);
+
+    try {
+      console.log('Please wait while the metrics are created and uploaded...');
+      let result = await postAllMetrics(metricsObj);
+      console.log(`Success: ${result} items created.`);
+    } catch (error) {
+      // Error posting metrics objects
+      logger.error(error);
+    }
+
+    console.log('\nDUP METRICS BACKFILL - COMPLETE');
+    console.log('********************');
+  } catch (error) {
+    logger.error(error);
+  }
+}
+
+run();


### PR DESCRIPTION
### Jira Ticket:

BRS-1020

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-1020

### Description:

This change is the API portion of BRS-1020. The accompanying admin side changes will follow.

This change adds 3 major areas of functionality to the API:

1. A new lambda `writeMetrics` that runs on a 5 minute cronjob. When `writeMetrics` is run, all parks and facilities are checked for changes on the current day, plus any days into the future where there exists a reservation object for that facility. The data from passes and reservations objects for all the facilities are collated and stored in a daily metrics item in a new `parksreso-metrics` table with the following primary key:
```
pk: metrics::<parkORCS>::<Facility Name>
sk: shortDate
```
Because this lambda is run every 5 minutes, existing metrics objects will be overwritten frequently to keep them up to date. Once a date has passed, there will exist one metrics object for that date with all the daily information for the given park/facility, including an hourly breakdown of check ins.

2. A new lambda `readMetrics` which is responsible for authenticating users and querying the db for metrics objects on a given date or between two given dates so that the metrics can be displayed in the front end.

3. A developer script `backfillMetrics.js` that allows developers to manually run the metrics gathering and creation logic from `writeMetrics` on any given date or date range. This will allow for the creation of metrics on dates already passed before this logic was introduced to the API. 

All new functionality in this change is named with `metrics`. There is existing functionality under `metric` that is obsoleted by this change and should be removed in a future ticket. 

Below is an example of a metrics object that was created by the cron running between the hours of 09:00 and 10:00 on 2023-03-28. Note there are only 5 passes in this example and they were checked in between 09:00 and 10:00. The `capacity[timeslot].passStatuses` object only gets updated with `active`, `reserved`, `cancelled` and `expired` subfields if there are passes with those statuses included in the metrics item.

```
    {
        "lastUpdated": "2023-03-28T10:09:37.713-07:00",
        "sk": "2023-03-28",
        "cancelled": 0,
        "capacities": {
            "AM": {
                "baseCapacity": 14,
                "capacityModifier": 0,
                "checkedIn": 5,
                "passStatuses": {
                    "active": 5
                },
                "availablePasses": 9,
                "overbooked": 0
            },
            "PM": {
                "baseCapacity": 10,
                "capacityModifier": 0,
                "checkedIn": 0,
                "passStatuses": {},
                "availablePasses": 10,
                "overbooked": 0
            }
        },
        "pk": "metrics::0015::P1 and Lower P5",
        "totalPasses": 5,
        "fullyBooked": false,
        "hourlyData": [
            {
                "hour": 0,
                "checkedIn": 0
            },
            {
                "hour": 1,
                "checkedIn": 0
            },
            {
                "hour": 2,
                "checkedIn": 0
            },
            {
                "hour": 3,
                "checkedIn": 0
            },
            {
                "hour": 4,
                "checkedIn": 0
            },
            {
                "hour": 5,
                "checkedIn": 0
            },
            {
                "hour": 6,
                "checkedIn": 0
            },
            {
                "hour": 7,
                "checkedIn": 0
            },
            {
                "hour": 8,
                "checkedIn": 0
            },
            {
                "hour": 9,
                "checkedIn": 5
            },
            {
                "hour": 10,
                "checkedIn": 0
            },
            {
                "hour": 11,
                "checkedIn": 0
            },
            {
                "hour": 12,
                "checkedIn": 0
            },
            {
                "hour": 13,
                "checkedIn": 0
            },
            {
                "hour": 14,
                "checkedIn": 0
            },
            {
                "hour": 15,
                "checkedIn": 0
            },
            {
                "hour": 16,
                "checkedIn": 0
            },
            {
                "hour": 17,
                "checkedIn": 0
            },
            {
                "hour": 18,
                "checkedIn": 0
            },
            {
                "hour": 19,
                "checkedIn": 0
            },
            {
                "hour": 20,
                "checkedIn": 0
            },
            {
                "hour": 21,
                "checkedIn": 0
            },
            {
                "hour": 22,
                "checkedIn": 0
            },
            {
                "hour": 23,
                "checkedIn": 0
            }
        ]
    }```
