### PR TITLE
BRS-1089: switching pass lookup to search on manualLookup GSI

### DIFF
--- a/lambda/readPass/index.js
+++ b/lambda/readPass/index.js
@@ -40,11 +40,11 @@ exports.handler = async (event, context) => {
 
       // Get all the passes for a specific facility
       if (event.queryStringParameters.date) {
-        // Use GSI on shortPassDate if date is provided
+        // Use GSI on manualLookupif date is provided
         const shortDate = DateTime.fromISO(event.queryStringParameters.date).toISODate();
 
         queryObj.ExpressionAttributeValues = {};
-        queryObj.IndexName = 'shortPassDate-index';
+        queryObj.IndexName = 'manualLookup-index';
         queryObj.ExpressionAttributeValues[':shortPassDate'] = { S: shortDate };
         queryObj.ExpressionAttributeValues[':facilityName'] = { S: event.queryStringParameters.facilityName };
         queryObj.KeyConditionExpression = 'shortPassDate =:shortPassDate AND facilityName =:facilityName';


### PR DESCRIPTION
### Jira Ticket:

BRS-1088/1089/1017

### Jira Ticket URL:

https://bcparksdigital.atlassian.net/browse/BRS-1089

### Description:

The old GSI for `readPass` does not project the checked-in status of passes. Switching the GSI to `manualLookup`, which projects all pass fields.
