### PR TITLE
BRS: 267 - Add Safety Video To Park DUP

### DIFF
--- a/lambda/writePark/index.js
+++ b/lambda/writePark/index.js
@@ -190,6 +190,19 @@ async function updateItem(obj, context) {
     };
   }
 
+  updateParams.UpdateExpression = updateParams.UpdateExpression + ' videoLink =:videoLink,';
+  if (obj?.park?.videoLink) {
+    updateParams.ExpressionAttributeValues = {
+      ...updateParams.ExpressionAttributeValues,
+      ':videoLink': AWS.DynamoDB.Converter.input(obj.park.videoLink)
+    };
+  } else {
+    updateParams.ExpressionAttributeValues = {
+      ...updateParams.ExpressionAttributeValues,
+      ':videoLink': { NULL: true }
+    };
+  }
+
   // Trim the last , from the updateExpression
   updateParams.UpdateExpression = updateParams.UpdateExpression.slice(0, -1);
 


### PR DESCRIPTION
### Jira Ticket:

BRS-267 - Add safety video to Park Information
Links to DUP-PUBLIC PR: https://github.com/bcgov/parks-reso-public/pull/269
Links to DUP-ADMIN PR: https://github.com/bcgov/parks-reso-admin/pull/304

### Jira Ticket URL:

https://github.com/orgs/bcgov/projects/49/views/2?pane=issue&itemId=39881272

### Description:

Added logic to handle video links being added to parks during PUT request. Can only be done through DUP-ADMIN when editing an existing park.