### PR TITLE
BRS-311: Disable edit park name through DUP Admin

### DIFF
--- a/lambda/writePark/index.js
+++ b/lambda/writePark/index.js
@@ -131,16 +131,6 @@ async function updateItem(obj, context) {
     ...('winterWarning' in obj && { ':winterWarning': AWS.DynamoDB.Converter.input(obj.winterWarning) })
   };
   // Reserved Words
-  if (obj?.park?.name) {
-    updateParams.UpdateExpression = updateParams.UpdateExpression + ' #up_name =:name,';
-    updateParams.ExpressionAttributeValues = {
-      ...updateParams.ExpressionAttributeValues,
-      ':name': AWS.DynamoDB.Converter.input(obj.park.name)
-    };
-    updateParams.ExpressionAttributeNames = {
-      '#up_name': 'name'
-    };
-  }
   if (obj?.park?.capacity) {
     updateParams.UpdateExpression = updateParams.UpdateExpression + ' #up_capacity =:capacity,';
     updateParams.ExpressionAttributeValues = {


### PR DESCRIPTION
### Jira Ticket:

BRS-311

Links to [DUP - Admin - 313](https://github.com/bcgov/parks-reso-admin/pull/313)
### Jira Ticket URL:
[DUP Admin -> The "Park name" should be read only in edit mode.#311](https://github.com/orgs/bcgov/projects/49/views/2?pane=issue&itemId=42084240)

### Description:
Removed updating park name through api writePark function
