### PR TITLE
PDR-288-1 adding Authorization to Axios headers for updateParkName

### DIFF
--- a/lambda/dataRegisterUtils.js
+++ b/lambda/dataRegisterUtils.js
@@ -10,7 +10,8 @@ async function getCurrentNameData(identifier) {
       method: 'get',
       url: url,
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'Authorization': 'None'
       }
     })
     return data;


### PR DESCRIPTION
### Jira Ticket:

PDR-288

### Jira Ticket URL:

Relates to https://github.com/bcgov/parks-reso-api/issues/288

### Description:

Partially fixes the issue where the nightly fetch script would not collect updated name data from the data registry. The original PR was submitted before the Authorizer code landed, which changed how the data register provides name data slightly. The data register now requires an `Authorization` header, even if no auth token is provided. This has been added in in this change.

The nightly update will still not work due to https://github.com/bcgov/parks-data-register/issues/167. The data register will allow the first park to be updated but will deny all future calls as the endpoints are different between parks. 
