### PR TITLE
122: Adding x-api-key for data register integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,4 @@ Prod pipeline is triggered by removing the `pre-release` tag from a release.
 Config service is used to alter frontend via DynamoDB. In Dynamo, an item with the PK and SK of config must exist. Within the attributes, you are able to set certain configurations such as `KEYCLOAK_ENABLED`, `API_LOCATION`, and `debugMode`.
 
 This item is request by the front ends upon client connection.
+

--- a/lambda/dataRegisterUtils.js
+++ b/lambda/dataRegisterUtils.js
@@ -2,6 +2,7 @@ const axios = require('axios');
 const { logger } = require('./logger');
 
 const DATA_REGISTRY_URL = process.env.DATA_REGISTRY_URL;
+const DATA_REGISTER_NAME_API_KEY = process.env.DATA_REGISTER_NAME_API_KEY;
 
 async function getCurrentNameData(identifier) {
   const url = DATA_REGISTRY_URL + `/parks/${identifier}/name?status=current`
@@ -11,7 +12,8 @@ async function getCurrentNameData(identifier) {
       url: url,
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': 'None'
+        'Authorization': 'None',
+        'x-api-key': DATA_REGISTER_NAME_API_KEY
       }
     })
     return data;

--- a/terraform/src/updateParkName.tf
+++ b/terraform/src/updateParkName.tf
@@ -13,6 +13,7 @@ resource "aws_lambda_function" "update_park_names" {
     variables = {
       TABLE_NAME                     = aws_dynamodb_table.park_dup_table.name,
       DATA_REGISTRY_URL              = data.aws_ssm_parameter.data_registry_url.value,
+      DATA_REGISTER_NAME_API_KEY     = data.aws_ssm_parameter.data_register_name_api_key.value,
       LOG_LEVEL                      = "info"
     }
   }

--- a/terraform/src/variables.tf
+++ b/terraform/src/variables.tf
@@ -11,6 +11,10 @@ variable "target_env" {
   description = "target environment"
 }
 
+data "aws_ssm_parameter" "data_register_name_api_key" {
+  name = "/parks-ar-api/data-register-name-api-key"
+}
+
 variable "captcha_sign_expiry" {
   default = "5"
   description = "CAPTCHA JWT signature expiry duration in minutes"


### PR DESCRIPTION
This adds the header to the data register integration request. Parameter store contains the value and is injected into the environment vars for the name update cronjob.