### PR TITLE
BRS-280: Adjust AM pass expiry

### DIFF
--- a/lambda/passUtils.js
+++ b/lambda/passUtils.js
@@ -6,7 +6,7 @@ const AWS = require('aws-sdk');
 
 // default opening/closing hours in 24h time
 const DEFAULT_AM_OPENING_HOUR = 7;
-const DEFAULT_PM_OPENING_HOUR = 13;
+const DEFAULT_PM_OPENING_HOUR = 12;
 
 async function getPersonalizationAttachment(parkIdentifier, registrationNumber, qrCode = false) {
   if (qrCode) {


### PR DESCRIPTION
### Jira Ticket:

[BRS-280](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=42572823)

Links to: [Public PR](https://github.com/bcgov/parks-reso-public/pull/269)

### Jira Ticket URL:

[https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=42572823](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=42572823)

### Description:
Changed the PM start time to noon which will make AM passes expired at the time.