### PR TITLE
PDR-309 adding status and passesRequired to metrics csv

### DIFF
--- a/lambda/metricsUtils.js
+++ b/lambda/metricsUtils.js
@@ -1,6 +1,7 @@
 const AWS = require('aws-sdk');
 const { DateTime } = require("luxon");
 const { METRICS_TABLE_NAME, TABLE_NAME, TIMEZONE, runQuery, dynamodb, getOne } = require("./dynamoUtil");
+const { checkPassesRequired } = require("./reservationObjUtils");
 const { logger } = require("./logger");
 
 const MAX_TRANSACTION_SIZE = 25;
@@ -94,7 +95,9 @@ async function createMetric(park, facility, date) {
     totalPasses: totalUsedPasses,
     cancelled: totalCancelledPasses,
     fullyBooked: totalUsedPasses >= totalCapacity ? true : false,
-    capacities: capacities
+    capacities: capacities,
+    status: resObj?.status || facility.status.state || null,
+    passesRequired: resObj?.passesRequired || checkPassesRequired(facility, date) || null
   }
 
   if (hourlyData.length) {

--- a/lambda/reservationObjUtils.js
+++ b/lambda/reservationObjUtils.js
@@ -87,7 +87,8 @@ async function createNewReservationsObj(
     pk: reservationsObjectPK,
     sk: bookingPSTShortDate,
     capacities: {},
-    status: facility.status.state
+    status: facility.status.state,
+    passesRequired: checkPassesRequired(facility, bookingPSTShortDate)
   };
 
   // We are initing capacities
@@ -119,6 +120,28 @@ async function createNewReservationsObj(
   }
   return res;
 };
+
+// check if passes are required on the date
+function checkPassesRequired(facility, shortDate) {
+  if (Object.keys(facility?.bookingDays).find((e) => facility.bookingDays.e === false)) {
+    // there is at least 1 day of the week where passes are not required.
+    const date = DateTime.fromFormat(shortDate, 'yyyy-LL-dd').setZone(TIMEZONE);
+    const day = date.toFormat('c');
+    // luxon days of the week are 1-indexed starting on Monday
+    if (facility?.bookingDays[day]) {
+      // passes are required
+      return true;
+    }
+    // if here, passes are not required. Check if bookableHolidays override the day
+    if (facility?.bookableHolidays.find((e) => e === shortDate)) {
+      // passes are required
+      return true;
+    }
+    // passes are not required.
+    return false;
+  }
+  return true;
+}
 
 async function getFutureReservationObjects(parkSk, facilityName) {
   let futureResObjects = [];
@@ -283,6 +306,7 @@ async function processReservationObjects(resObjs, timesToUpdate, timesToRemove, 
 
 // Can be populated with more metadata fields in the future if necessary
 async function updateReservationsObjectMeta(pk, sk, status) {
+  console.log('status');
   const updateReservationsObject = {
     TableName: TABLE_NAME,
     Key: {
@@ -503,5 +527,6 @@ module.exports = {
   getFutureReservationObjects,
   processReservationObjects,
   formatPublicReservationObject,
-  createNewReservationsObj
+  createNewReservationsObj,
+  checkPassesRequired
 };

--- a/lambda/reservationObjUtils.js
+++ b/lambda/reservationObjUtils.js
@@ -306,7 +306,6 @@ async function processReservationObjects(resObjs, timesToUpdate, timesToRemove, 
 
 // Can be populated with more metadata fields in the future if necessary
 async function updateReservationsObjectMeta(pk, sk, status) {
-  console.log('status');
   const updateReservationsObject = {
     TableName: TABLE_NAME,
     Key: {


### PR DESCRIPTION
Completes #309.

When reservation objects are updated, they now capture additional metrics: 

- status: the state of the facility (open || closed)
- passesRequired: whether or not passes are required on the date, based on `bookingDays` and `bookableHolidays` attributes of the facility.

Note that a status of `closed` does not mean passes are not required. They are two mutually exclusive properties.

With this new addition, metrics objects now also capture `status` and `passesRequired` values. These are now included in the metrics csv that can be downloaded from the metrics route in DUP admin (captured in a different PR). 
