### PR TITLE
PDR-346 expire DUP passes at 6pm same day

### DIFF
--- a/lambda/checkExpiry/index.js
+++ b/lambda/checkExpiry/index.js
@@ -32,7 +32,7 @@ exports.handler = async (event, context) => {
       if (currentPSTDateTime.hour >= 18) {
         logger.debug("Expiring:", pass);
         passesToChange.push(pass);
-        break;
+        continue;
       }
 
       // If pass date converted to PST is before the end of yesterday, it's definitely expire (AM/PM/DAY)
@@ -40,6 +40,7 @@ exports.handler = async (event, context) => {
       if (passPSTDateTime <= yesterdayEndPSTDateTime){
         logger.debug("Expiring:", pass);
         passesToChange.push(pass);
+        continue;
       }
 
       // If AM, see if we're currently in the afternoon or later compared to the pass date's noon time.


### PR DESCRIPTION
Fixes PDR-346 https://github.com/bcgov/parks-reso-api/issues/346

`checkExpiry` cronjob runs every hour. When it runs after 18:00, all active passes in the system are set to `expired` instead of waiting until midnight to do this.
