### PR TITLE
BRS-312: Fix Site Metrics Results when Facilities were Noted as "Pass Not Required"

### DIFF
--- a/samNode/handlers/writePass/__tests__/writePass.test.js
+++ b/samNode/handlers/writePass/__tests__/writePass.test.js
@@ -481,6 +481,13 @@ describe('Pass Successes', () => {
         })
       };
     });
+    jest.mock('/opt/reservationLayer', () => {
+      return {
+        createNewReservationsObj: jest.fn(() => {
+          // Do nothing, don't throw
+        }),
+      };
+    });
     const writePassHandler = require('../index');
     process.env.ADMIN_FRONTEND = 'http://localhost:4300';
     process.env.PASS_MANAGEMENT_ROUTE = '/pass-management';

--- a/samNode/layers/metricsLayer/metricsLayer.js
+++ b/samNode/layers/metricsLayer/metricsLayer.js
@@ -97,6 +97,12 @@ async function createMetric(park, facility, date) {
     totalCancelledPasses += capacities[time].passStatuses['cancelled'] || 0;
   }
 
+  let passesRequired = checkPassesRequired(facility, date)
+
+  if (park?.status == 'closed') {
+    passesRequired = false;
+  }
+
   let metricsObj = {
     pk: `metrics::${park.sk}::${facility.sk}`,
     sk: date,
@@ -106,7 +112,7 @@ async function createMetric(park, facility, date) {
     fullyBooked: totalUsedPasses >= totalCapacity ? true : false,
     capacities: capacities,
     status: resObj?.status || facility.status.state || null,
-    passesRequired: resObj?.passesRequired || checkPassesRequired(facility, date) || null,
+    passesRequired: resObj?.passesRequired || passesRequired,
     specialClosure: !!park.specialClosure
   }
 


### PR DESCRIPTION
### Ticket:
BRS-312

### Ticket URL:
[#312](https://github.com/bcgov/parks-reso-admin/issues/312)

### Description:

#### Improves the logic for determining whether passes are required for a facility on a given date.
- Ensures that if a park is closed, passes are not required.
- Adjusts capacity calculations to set capacity and available passes to zero if passes are not required.

#### Refactoring and Bug Fixes:
- Fixes potential issues in the `checkPassesRequired` function by ensuring `bookableHolidays` is treated as an array and optimizing the logic for determining pass requirements.
- Updates reservation object creation to correctly apply the passes-required logic.

#### `dynamoRestore` script:
- Changes the default table name from `parksreso` to `ParksDUP`.
- Ensure the final batch is processed

