### PR TITLE
BRS-504: Daylight savings 2025

### DIFF
--- a/samNode/template.yaml
+++ b/samNode/template.yaml
@@ -1000,7 +1000,7 @@ Resources:
         ScheduleEvent:
           Type: Schedule
           Properties:
-            Schedule: "cron(0 0 * * ? *)" #  Every day at 4pm PST
+            Schedule: "cron(0 1 * * ? *)" #  Every day at 4pm PDT
 
   SendSurveyFunction:
     Type: AWS::Serverless::Function
@@ -1115,7 +1115,7 @@ Resources:
           ScheduleEvent:
             Type: Schedule
             Properties:
-              Schedule: "cron(57,58,59 12 ? * * *)" # Fires at 5:57, 5:58, 5:59 in the morning PST
+              Schedule: "cron(57,58,59 13 ? * * *)" # Fires at 5:57, 5:58, 5:59 in the morning PDT
 
   WriteConfigFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Ticket: [504](https://github.com/orgs/bcgov/projects/49/views/1?pane=issue&itemId=104931620&issue=bcgov%7Cparks-reso-public%7C504)

Notes: This is just an adjustment for the cron schedule. There will need to be an update to the expiry times (FE + BE) before DUP is active again in may.