### PR TITLE
BRS-438-2: Make Metrics Cronjob Permanent

### DIFF
--- a/samNode/template.yaml
+++ b/samNode/template.yaml
@@ -157,7 +157,7 @@ Parameters:
     Default: "archivedPasses"
   WriteMetricsCron:
     Type: String
-    Default: "cron(0 8,16,24 * * ? *)" 
+    Default: "cron(0 1,8,17 * * ? *)"
   
 Resources:
   #########


### PR DESCRIPTION
### Ticket:
BRS-438

### Ticket URL:
#438 

### Description:
- Fix time for cron, can't go to `24` in a cron

