### PR TITLE
DUP-312-Sendback: Fix to Facility Status, Now Reflects Park Status; Add Testing

### DIFF
--- a/samNode/handlers/writeFacility/__tests__/writeFacility.test.js
+++ b/samNode/handlers/writeFacility/__tests__/writeFacility.test.js
@@ -196,6 +196,15 @@ describe('Facility Access', () => {
     jest.mock('/opt/permissionLayer', () => {
       return mockedSysadmin;
     });
+    jest.mock('/opt/reservationLayer', () => {
+      return {
+        createNewReservationsObj: jest.fn(() =>
+          Promise.resolve({
+            status: 'success'
+          })
+        ),
+      }
+    });
 
     const dynamoClient = new DynamoDBClient({
       region: REGION,
@@ -257,6 +266,15 @@ describe('Facility Access', () => {
   test('QR Codes enabled on update', async () => {
     jest.mock('/opt/permissionLayer', () => {
       return mockedSysadmin;
+    });
+    jest.mock('/opt/reservationLayer', () => {
+      return {
+        createNewReservationsObj: jest.fn(() =>
+          Promise.resolve({
+            status: 'success'
+          })
+        ),
+      }
     });
 
     const dynamoClient = new DynamoDBClient({

--- a/samNode/layers/__tests__/reservationLayer.test.js
+++ b/samNode/layers/__tests__/reservationLayer.test.js
@@ -1,0 +1,119 @@
+const { checkPassesRequired } = require('../reservationLayer/reservationLayer');
+
+const mockFacility = {
+  pk: 'facility::Test Park',
+  sk: 'Test Facility',
+  name: 'Test Facility',
+  description: 'A Parking Lot!',
+  isUpdating: false,
+  type: 'Parking',
+  bookingTimes: {
+    AM: { max: '100' },
+    PM: { max: '200' },
+    DAY: { max: '300' }
+  },
+  bookingDays: {
+    1: true,
+    2: true, // Tuesday e.g. 2025-04-29
+    3: true,
+    4: true,
+    5: true,
+    6: true,
+    7: false // Sunday e.g. 2025-04-27, 2025-04-20 (Easter)
+  },
+  bookingDaysRichText: '',
+  bookableHolidays: ['2025-04-20'],
+  status: { stateReason: '', state: 'open' },
+  qrcode: true,
+  visible: true
+};
+
+describe('checkPassesRequired', () => {
+  let passesRequired = checkPassesRequired(mockFacility, '2025-04-29');
+  test('should return true when a facility requires passes', () => {
+    expect(passesRequired).toBeTruthy();
+  });
+
+  let passesNotRequired = checkPassesRequired(mockFacility, '2025-04-27');
+  test("should return false when a facility doesn't require passes", () => {
+    expect(passesNotRequired).toBeFalsy();
+  });
+
+  let bookableHoliday = checkPassesRequired(mockFacility, '2025-04-20');
+  test('should return true when a facility requires passes on a holiday', () => {
+    expect(bookableHoliday).toBeTruthy();
+  });
+});
+
+let baseLayerMockConfig = {
+  parkState: 'open',
+  marshallCaptureRef: null
+};
+
+jest.mock('/opt/baseLayer', () => ({
+  getOne: jest.fn(() =>
+    Promise.resolve({
+      status: {
+        state: baseLayerMockConfig.parkState,
+        stateReason: ''
+      }
+    })
+  ),
+  PutItemCommand: jest.fn(obj => obj),
+  marshall: jest.fn(obj => {
+    if (baseLayerMockConfig.marshallCaptureRef) {
+      baseLayerMockConfig.marshallCaptureRef.obj = obj;
+    }
+    return obj;
+  }),
+  unmarshall: jest.fn(obj => obj),
+  dynamoClient: {
+    send: jest.fn(obj => Promise.resolve({ success: true }))
+  },
+  logger: {
+    info: jest.fn(),
+    debug: jest.fn()
+  }
+}));
+
+describe('createNewReservationsObj', () => {
+  test("should show that passes are NOT required and capacities are 0 because the park is open and facility's booking day is set to false", async () => {
+    const capture = {};
+    baseLayerMockConfig.parkState = 'open';
+    baseLayerMockConfig.marshallCaptureRef = capture;
+
+    const { createNewReservationsObj } = require('../reservationLayer/reservationLayer');
+    await createNewReservationsObj(mockFacility, 'reservations::1234::Test Lake', '2025-04-27'); // Passes not required this day
+
+    expect(capture.obj.passesRequired).toBe(false);
+    expect(capture.obj.capacities.AM.baseCapacity).toBe(0);
+    expect(capture.obj.capacities.PM.baseCapacity).toBe(0);
+    expect(capture.obj.capacities.DAY.baseCapacity).toBe(0);
+  });
+
+  test("should show that passes are required and capacities are normal because the park is open and facility's booking day is set to true", async () => {
+    const capture = {};
+    baseLayerMockConfig.parkState = 'open';
+    baseLayerMockConfig.marshallCaptureRef = capture;
+
+    const { createNewReservationsObj } = require('../reservationLayer/reservationLayer');
+    await createNewReservationsObj(mockFacility, 'reservations::1234::Test Lake', '2025-04-29'); // Passes required this day
+    expect(capture.obj.passesRequired).toBe(true);
+    expect(capture.obj.capacities.AM.baseCapacity).toBe('100');
+    expect(capture.obj.capacities.PM.baseCapacity).toBe('200');
+    expect(capture.obj.capacities.DAY.baseCapacity).toBe('300');
+  });
+
+  test("should show that passes are NOT required and capacities are 0 because the PARK is CLOSED, regardless of facility's pass status", async () => {
+    const capture = {};
+    baseLayerMockConfig.parkState = 'closed'; // Park's status state is 'closed'
+    baseLayerMockConfig.marshallCaptureRef = capture;
+    
+    const { createNewReservationsObj } = require('../reservationLayer/reservationLayer');
+    await createNewReservationsObj(mockFacility, 'reservations::1234::Test Lake', '2025-04-29'); // Passes required this day
+    expect(capture.obj.passesRequired).toBe(false);
+    expect(capture.obj.capacities.AM.baseCapacity).toBe(0);
+    expect(capture.obj.capacities.PM.baseCapacity).toBe(0);
+    expect(capture.obj.capacities.DAY.baseCapacity).toBe(0);
+  });
+});

--- a/samNode/layers/facilityLayer/facilityLayer.js
+++ b/samNode/layers/facilityLayer/facilityLayer.js
@@ -1,5 +1,5 @@
 
-const { dynamoClient, UpdateItemCommand, TABLE_NAME, logger, unmarshall } = require('/opt/baseLayer');
+const { dynamoClient, UpdateItemCommand, TABLE_NAME, logger, unmarshall, sendResponse } = require('/opt/baseLayer');
 
 async function setFacilityLock(pk, sk) {
   const facilityLockObject = {

--- a/samNode/layers/reservationLayer/reservationLayer.js
+++ b/samNode/layers/reservationLayer/reservationLayer.js
@@ -80,11 +80,15 @@ async function createNewReservationsObj(
 
   const bookingTimeTypes = Object.keys(facility.bookingTimes);
 
+  let facilityStatus = facility.status.state;
   let passesRequired = checkPassesRequired(facility, bookingPSTShortDate)
-  const parkOrcs = facility.pk.replace('/\D/g','');
+  const parkOrcs = facility.pk.replace(/\D/g, '');
   const park = unmarshall(await getOne('park', parkOrcs));
 
-  if (park?.status == 'closed') {
+  // If the park is closed, we need to ensure the facility's status is closed
+  // and that passes are deemed "not required".
+  if (park?.status.state == 'closed') {
+    facilityStatus = 'closed';
     passesRequired = false;
   }
 
@@ -92,7 +96,7 @@ async function createNewReservationsObj(
     pk: reservationsObjectPK,
     sk: bookingPSTShortDate,
     capacities: {},
-    status: facility.status.state,
+    status: facilityStatus,
     passesRequired: passesRequired
   };
 


### PR DESCRIPTION
### Ticket:
BRS-312

### Ticket URL:
[#312](https://github.com/bcgov/parks-reso-admin/issues/312)

### Description:
- Fix so a park's status affects the facility's open status and passes required and capacities
- Fix a bug with the `createNewReservationObj` and retrieving a park from the db
- Add testing for these new items in `reservationLayer`