### PR TITLE
DUP-312-Sendback-1: Fix to Facility Status

### DIFF
--- a/samNode/layers/__tests__/reservationLayer.test.js
+++ b/samNode/layers/__tests__/reservationLayer.test.js
@@ -1,6 +1,6 @@
 const { checkPassesRequired } = require('../reservationLayer/reservationLayer');
 
-const mockFacility = {
+const mockFacilityOpen = {
   pk: 'facility::Test Park',
   sk: 'Test Facility',
   name: 'Test Facility',
@@ -28,18 +28,46 @@ const mockFacility = {
   visible: true
 };
 
+const mockFacilityClosed = {
+  pk: 'facility::Test Park',
+  sk: 'Test Facility',
+  name: 'Test Facility',
+  description: 'A Parking Lot!',
+  isUpdating: false,
+  type: 'Parking',
+  bookingTimes: {
+    AM: { max: '100' },
+    PM: { max: '200' },
+    DAY: { max: '300' }
+  },
+  bookingDays: {
+    1: true,
+    2: true, // Tuesday e.g. 2025-04-29
+    3: true,
+    4: true,
+    5: true,
+    6: true,
+    7: false // Sunday e.g. 2025-04-27, 2025-04-20 (Easter)
+  },
+  bookingDaysRichText: '',
+  bookableHolidays: ['2025-04-20'],
+  status: { stateReason: 'Bears in the area!', state: 'closed' },
+  qrcode: true,
+  visible: true
+};
+
 describe('checkPassesRequired', () => {
-  let passesRequired = checkPassesRequired(mockFacility, '2025-04-29');
+  let passesRequired = checkPassesRequired(mockFacilityOpen, '2025-04-29');
   test('should return true when a facility requires passes', () => {
     expect(passesRequired).toBeTruthy();
   });
 
-  let passesNotRequired = checkPassesRequired(mockFacility, '2025-04-27');
+  let passesNotRequired = checkPassesRequired(mockFacilityOpen, '2025-04-27');
   test("should return false when a facility doesn't require passes", () => {
     expect(passesNotRequired).toBeFalsy();
   });
 
-  let bookableHoliday = checkPassesRequired(mockFacility, '2025-04-20');
+  let bookableHoliday = checkPassesRequired(mockFacilityOpen, '2025-04-20');
   test('should return true when a facility requires passes on a holiday', () => {
     expect(bookableHoliday).toBeTruthy();
   });
@@ -83,7 +111,7 @@ describe('createNewReservationsObj', () => {
     baseLayerMockConfig.marshallCaptureRef = capture;
 
     const { createNewReservationsObj } = require('../reservationLayer/reservationLayer');
-    await createNewReservationsObj(mockFacility, 'reservations::1234::Test Lake', '2025-04-27'); // Passes not required this day
+    await createNewReservationsObj(mockFacilityOpen, 'reservations::1234::Test Lake', '2025-04-27'); // Passes not required this day
 
     expect(capture.obj.passesRequired).toBe(false);
     expect(capture.obj.capacities.AM.baseCapacity).toBe(0);
@@ -97,23 +125,37 @@ describe('createNewReservationsObj', () => {
     baseLayerMockConfig.marshallCaptureRef = capture;
 
     const { createNewReservationsObj } = require('../reservationLayer/reservationLayer');
-    await createNewReservationsObj(mockFacility, 'reservations::1234::Test Lake', '2025-04-29'); // Passes required this day
+    await createNewReservationsObj(mockFacilityOpen, 'reservations::1234::Test Lake', '2025-04-29'); // Passes required this day
     expect(capture.obj.passesRequired).toBe(true);
     expect(capture.obj.capacities.AM.baseCapacity).toBe('100');
     expect(capture.obj.capacities.PM.baseCapacity).toBe('200');
     expect(capture.obj.capacities.DAY.baseCapacity).toBe('300');
   });
 
+  test("should show that passes are NOT required and capacities are 0 because the FACILITY is CLOSED, regardless of facility's pass status", async () => {
+    const capture = {};
+    baseLayerMockConfig.parkState = 'open';
+    baseLayerMockConfig.marshallCaptureRef = capture;
+    
+    const { createNewReservationsObj } = require('../reservationLayer/reservationLayer');
+    await createNewReservationsObj(mockFacilityClosed, 'reservations::1234::Test Lake', '2025-04-29'); // Passes required this day
+    expect(capture.obj.passesRequired).toBe(false);
+    expect(capture.obj.capacities.AM.baseCapacity).toBe(0);
+    expect(capture.obj.capacities.PM.baseCapacity).toBe(0);
+    expect(capture.obj.capacities.DAY.baseCapacity).toBe(0);
+  });
+  
   test("should show that passes are NOT required and capacities are 0 because the PARK is CLOSED, regardless of facility's pass status", async () => {
     const capture = {};
     baseLayerMockConfig.parkState = 'closed'; // Park's status state is 'closed'
     baseLayerMockConfig.marshallCaptureRef = capture;
     
     const { createNewReservationsObj } = require('../reservationLayer/reservationLayer');
-    await createNewReservationsObj(mockFacility, 'reservations::1234::Test Lake', '2025-04-29'); // Passes required this day
+    await createNewReservationsObj(mockFacilityOpen, 'reservations::1234::Test Lake', '2025-04-29'); // Passes required this day
     expect(capture.obj.passesRequired).toBe(false);
     expect(capture.obj.capacities.AM.baseCapacity).toBe(0);
     expect(capture.obj.capacities.PM.baseCapacity).toBe(0);
     expect(capture.obj.capacities.DAY.baseCapacity).toBe(0);
   });
+
 });

--- a/samNode/layers/reservationLayer/reservationLayer.js
+++ b/samNode/layers/reservationLayer/reservationLayer.js
@@ -136,6 +136,10 @@ function checkPassesRequired(facility, shortDate) {
   const date = DateTime.fromFormat(shortDate, "yyyy-LL-dd", { zone: TIMEZONE });
   const day = date.toFormat("c").toString();
 
+  if (facility.status.state == 'closed') {
+    return false
+  }
+
   // Ensure bookableHolidays is an array; if not, default to an empty array
   const bookableHolidays = Array.isArray(facility?.bookableHolidays) ? facility.bookableHolidays : []
 


### PR DESCRIPTION
### Ticket:
BRS-312

### Ticket URL:
[#312](https://github.com/bcgov/parks-reso-admin/issues/312)

### Description:
- Fix so the facility's status affects passes required when facility is 'open' or 'closed'
- Add missing test