### PR TITLE
DUP-312-Sendback-2: Properly Checks Park Status

### DIFF
--- a/samNode/layers/reservationLayer/reservationLayer.js
+++ b/samNode/layers/reservationLayer/reservationLayer.js
@@ -87,7 +87,7 @@ async function createNewReservationsObj(
 
   // If the park is closed, we need to ensure the facility's status is closed
   // and that passes are deemed "not required".
-  if (park?.status.state == 'closed') {
+  if (park?.status == 'closed') {
     facilityStatus = 'closed';
     passesRequired = false;
   }


### PR DESCRIPTION
### Ticket:
BRS-312

### Ticket URL:
[#312](https://github.com/bcgov/parks-reso-admin/issues/312)

### Description:
- Rewrite tests to follow testing pattern, as outlined [here](https://github.com/bcgov/parks-reso-admin/issues/312#issuecomment-2847766401).
- Fix an issue with checking the park status, now correctly finds the park's status in the `park` object