### PR TITLE
DUP-511 reject failed transactions leading to held pass

### DIFF
--- a/samNode/handlers/writePass/index.js
+++ b/samNode/handlers/writePass/index.js
@@ -526,6 +526,7 @@ async function transactWriteWithRetries(transactionObj, maxRetries = 3) {
       }
     } while (retryCount < maxRetries);
   }catch(error){
+    throw new CustomError('Failed to write transaction after retries', 500);
   }
 };
 


### PR DESCRIPTION
Relates to https://github.com/bcgov/parks-reso-public/issues/511.

DEVS: please review the comments in the above ticket and the code changes carefully, and determine whether or not you agree that the situation out lined in the ticket is a) possible and b) probably the cause of the ticket issues. 

QA: Please thoroughly smoke-test this change in the front end, including reviewing the behaviour of expired passes. This bug arose from unhandled transaction errors when creating a pass in the `held` state. We must ensure the intended behaviour occurs. 