### PR TITLE
BRS-469-1: Rework SQS Processor and add Dead Letter Queue

### DIFF
--- a/samNode/template.yaml
+++ b/samNode/template.yaml
@@ -1064,6 +1064,8 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt SqsGcnEmailQueue.Arn
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
 
   UpdateParkNameFunction:
     Type: AWS::Serverless::Function
@@ -1596,12 +1598,20 @@ Resources:
     Type: 'AWS::SQS::Queue'
     Properties:
       QueueName: !Ref SqsGCNQueueName
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt SqsGcnEmailDLQ.Arn
+        maxReceiveCount: 5
 
+  SqsGcnEmailDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${SqsGCNQueueName}-dlq"
+      
   SqsExpiryQueue:
     Type: 'AWS::SQS::Queue'
     Properties:
       QueueName: !Ref SqsExpiryQueueName
-      
+
 Outputs:
   ApiDeployment:
     Description: 'API Gateway endpoint URL for Stage for Config function'


### PR DESCRIPTION
### Ticket:

BRS-469

### Ticket URL:

#469 

### Description

- SQS Processor improvements
  - Batch failure handling: Added `batchItemFailures` array to properly handle partial batch failures and prevent reprocessing of successful messages
  - Enhanced error handling:
  - Implemented `NoRetry` error type for non-retriable failures (400/403 HTTP errors)
  - Only retry on certain errors (429, 500, 503, network issues)
  - Removed single retry logic: Replaced custom retry mechanism with SQS-native retry handling

- Update `template.yml`:
  - Added `FunctionResponseTypes: ReportBatchItemFailures` to enable partial batch failure reporting
  - Created `SqsGcnEmailDLQ` queue for messages that exceed retry limits
  - Configured DLQ with `maxReceiveCount: 5` for failed messages