### PR TITLE
Fix Cloudflare Turnstile token validation check

### DIFF
--- a/samNode/layers/permissionLayer/permissionLayer.js
+++ b/samNode/layers/permissionLayer/permissionLayer.js
@@ -248,7 +248,7 @@ exports.validateToken = async function (token) {
   });
 
   logger.debug(res.data);
-  if (!res.status == 200) {
+  if (res.status !== 200 || !res.data.success) {
     throw new CustomError('Invalid token.', 400);
   }
 };


### PR DESCRIPTION
Correct a logical bug in validateToken: replace the incorrect
'!res.status == 200'
with:
'res.status !== 200 || !res.data.success'
so the function properly rejects invalid tokens. This ensures both the HTTP status and the response's success flag are validated before proceeding.