### PR TITLE
feat(writePass): canonicalize email for duplicate-check

### DIFF
--- a/samNode/layers/__tests__/baseLayer.canonicalizeEmail.test.js
+++ b/samNode/layers/__tests__/baseLayer.canonicalizeEmail.test.js
@@ -1,0 +1,44 @@
+const { canonicalizeEmail } = require('../baseLayer/baseLayer');
+
+describe('canonicalizeEmail', () => {
+  test('lowercases and trims', () => {
+    expect(canonicalizeEmail('  USER@EXAMPLE.COM  ')).toBe('user@example.com');
+  });
+
+  test('strips +tag from local-part for any domain', () => {
+    expect(canonicalizeEmail('user+anything@example.com')).toBe('user@example.com');
+    expect(canonicalizeEmail('user+foo+bar@example.com')).toBe('user@example.com');
+  });
+
+  test('removes dots from local-part for gmail.com only', () => {
+    expect(canonicalizeEmail('a.b.c@gmail.com')).toBe('abc@gmail.com');
+    expect(canonicalizeEmail('a.b.c.d.e.f@gmail.com')).toBe('abcdef@gmail.com');
+    expect(canonicalizeEmail('a.b.c@googlemail.com')).toBe('abc@googlemail.com');
+  });
+
+  test('preserves dots in non-Gmail local-parts', () => {
+    expect(canonicalizeEmail('first.last@outlook.com')).toBe('first.last@outlook.com');
+    expect(canonicalizeEmail('a.b@example.com')).toBe('a.b@example.com');
+  });
+
+  test('combines + and . rules for gmail', () => {
+    expect(canonicalizeEmail('a.b.c+tag@gmail.com')).toBe('abc@gmail.com');
+  });
+
+  test('returns empty string for empty/invalid input', () => {
+    expect(canonicalizeEmail('')).toBe('');
+    expect(canonicalizeEmail(null)).toBe('');
+    expect(canonicalizeEmail(undefined)).toBe('');
+    expect(canonicalizeEmail(12345)).toBe('');
+  });
+
+  test('handles missing @ or trailing @ gracefully', () => {
+    expect(canonicalizeEmail('noat')).toBe('noat');
+    expect(canonicalizeEmail('trailing@')).toBe('trailing@');
+    expect(canonicalizeEmail('@leading.com')).toBe('@leading.com');
+  });
+
+  test('uses the LAST @ to split (defensive for unusual local-parts)', () => {
+    expect(canonicalizeEmail('weird@local@gmail.com')).toBe('weird@local@gmail.com');
+  });
+});

--- a/samNode/layers/__tests__/baseLayer.canonicalizeEmail.test.js
+++ b/samNode/layers/__tests__/baseLayer.canonicalizeEmail.test.js
@@ -1,4 +1,4 @@
-const { canonicalizeEmail } = require('../baseLayer/baseLayer');
+const { canonicalizeEmail } = require('/opt/baseLayer');
 
 describe('canonicalizeEmail', () => {
   test('lowercases and trims', () => {

--- a/samNode/layers/baseLayer/baseLayer.js
+++ b/samNode/layers/baseLayer/baseLayer.js
@@ -395,21 +395,21 @@ function canonicalizeEmail(email) {
  * @throws {CustomError} Throws an error if the booking date is invalid or if a reservation already exists.
  */
 async function checkPassExists(facilityName, email, type, bookingPSTShortDate) {
-  // Match by canonical form to catch Gmail dot/+ variants of the same mailbox.
-  // Falls back to comparing against the raw 'email' field for pre-canonicalization records.
+  // emailCanonical isn't projected on the GSI, so we filter on type+passStatus in DDB
+  // and do the canonical/raw email match in JS below. This still catches Gmail dot/+
+  // variants of the same mailbox once records carry emailCanonical, and falls back to
+  // raw email equality for any pre-canonicalization records.
   const emailCanonical = canonicalizeEmail(email);
   const existingPassCheckObject = {
     TableName: process.env.TABLE_NAME,
     IndexName: 'shortPassDate-index',
     KeyConditionExpression: 'shortPassDate = :shortPassDate AND facilityName = :facilityName',
-    FilterExpression: '(emailCanonical = :emailCanonical OR email = :email) AND #type = :type AND passStatus IN (:reserved, :active)',
+    FilterExpression: '#type = :type AND passStatus IN (:reserved, :active)',
     ExpressionAttributeNames: {
       '#type': 'type'
     },
     ExpressionAttributeValues: {
       ':facilityName': { S: facilityName },
-      ':email': { S: email },
-      ':emailCanonical': { S: emailCanonical },
       ':type': { S: type },
       ':shortPassDate': { S: bookingPSTShortDate },
       ':reserved': { S: 'reserved' },
@@ -434,10 +434,19 @@ async function checkPassExists(facilityName, email, type, bookingPSTShortDate) {
     throw new CustomError('Error while running query for existingPassCheckObject', 400);
   }
 
-  if (existingItems.Count > 0) {
+  // Match on canonicalized email (catches Gmail dot/+ variants) OR raw email
+  // (fallback for pre-canonicalization records).
+  const conflict = (existingItems.Items || []).find(item => {
+    const storedEmail = item.email && item.email.S;
+    const storedCanonical = item.emailCanonical && item.emailCanonical.S;
+    return (emailCanonical && storedCanonical === emailCanonical)
+        || (email && storedEmail === email);
+  });
+
+  if (conflict) {
     logger.info(
       `email account already has a reservation. Registration number: ${JSON.stringify(
-        existingItems?.Items[0]?.registrationNumber
+        conflict.registrationNumber
       )}`
     );
     throw new CustomError('This email account already has a reservation for this booking time. A reservation associated with this email for this booking time already exists. Please check to see if you already have a reservation for this time. If you do not have an email confirmation of your reservation please contact <a href="mailto:parkinfo@gov.bc.ca">parkinfo@gov.bc.ca</a>', 400);

--- a/samNode/layers/baseLayer/baseLayer.js
+++ b/samNode/layers/baseLayer/baseLayer.js
@@ -357,6 +357,35 @@ function visibleFilter(queryObj, isAdmin) {
 }
 
 /**
+ * Returns a canonical form of an email for duplicate-detection.
+ *
+ * - Lowercases and trims.
+ * - Strips "+suffix" from the local-part (most providers ignore it for delivery).
+ * - For gmail.com / googlemail.com, also strips dots from the local-part
+ *   (Gmail ignores them, so dot variants all hit the same inbox).
+ *
+ * The original email is still stored on the pass for confirmation delivery; this
+ * value is the index used for "have I seen this person before" checks.
+ *
+ * @param {string} email
+ * @returns {string} canonicalized email, or '' if input is empty/invalid.
+ */
+function canonicalizeEmail(email) {
+  if (!email || typeof email !== 'string') return '';
+  const trimmed = email.trim().toLowerCase();
+  const at = trimmed.lastIndexOf('@');
+  if (at < 1 || at === trimmed.length - 1) return trimmed;
+  let local = trimmed.slice(0, at);
+  const domain = trimmed.slice(at + 1);
+  const plusIdx = local.indexOf('+');
+  if (plusIdx >= 0) local = local.slice(0, plusIdx);
+  if (domain === 'gmail.com' || domain === 'googlemail.com') {
+    local = local.replace(/\./g, '');
+  }
+  return `${local}@${domain}`;
+}
+
+/**
  * Checks if a pass exists for the given parameters.
  *
  * @param {string} facilityName - The name of the facility.
@@ -366,17 +395,21 @@ function visibleFilter(queryObj, isAdmin) {
  * @throws {CustomError} Throws an error if the booking date is invalid or if a reservation already exists.
  */
 async function checkPassExists(facilityName, email, type, bookingPSTShortDate) {
+  // Match by canonical form to catch Gmail dot/+ variants of the same mailbox.
+  // Falls back to comparing against the raw 'email' field for pre-canonicalization records.
+  const emailCanonical = canonicalizeEmail(email);
   const existingPassCheckObject = {
     TableName: process.env.TABLE_NAME,
     IndexName: 'shortPassDate-index',
     KeyConditionExpression: 'shortPassDate = :shortPassDate AND facilityName = :facilityName',
-    FilterExpression: 'email = :email AND #type = :type AND passStatus IN (:reserved, :active)',
+    FilterExpression: '(emailCanonical = :emailCanonical OR email = :email) AND #type = :type AND passStatus IN (:reserved, :active)',
     ExpressionAttributeNames: {
       '#type': 'type'
     },
     ExpressionAttributeValues: {
       ':facilityName': { S: facilityName },
       ':email': { S: email },
+      ':emailCanonical': { S: emailCanonical },
       ':type': { S: type },
       ':shortPassDate': { S: bookingPSTShortDate },
       ':reserved': { S: 'reserved' },
@@ -426,6 +459,7 @@ async function checkPassExists(facilityName, email, type, bookingPSTShortDate) {
  * @throws {CustomError} - If the operation fails.
  */
 async function convertPassToReserved(decodedToken, passStatus, firstName, lastName, email, phoneNumber) {
+  const emailCanonical = canonicalizeEmail(email);
   const updateParams = {
     TableName: process.env.TABLE_NAME,
     Key: {
@@ -439,6 +473,7 @@ async function convertPassToReserved(decodedToken, passStatus, firstName, lastNa
       ':searchFirstName': { S: firstName.toLowerCase() },
       ':searchLastName': { S: lastName.toLowerCase() },
       ':email': { S: email },
+      ':emailCanonical': { S: emailCanonical },
       ':empty_list': { L: [] }, // For pass objects which do not have an audit property.
       ':dateUpdated': { S: DateTime.now().toUTC().toISO() },
       ':audit_val': {
@@ -459,7 +494,7 @@ async function convertPassToReserved(decodedToken, passStatus, firstName, lastNa
         ]
       }
     },
-    UpdateExpression: 'SET passStatus = :statusValue, firstName = :firstName, lastName = :lastName, searchFirstName = :searchFirstName, searchLastName = :searchLastName, email = :email, audit = list_append(if_not_exists(audit, :empty_list), :audit_val), dateUpdated = :dateUpdated',
+    UpdateExpression: 'SET passStatus = :statusValue, firstName = :firstName, lastName = :lastName, searchFirstName = :searchFirstName, searchLastName = :searchLastName, email = :email, emailCanonical = :emailCanonical, audit = list_append(if_not_exists(audit, :empty_list), :audit_val), dateUpdated = :dateUpdated',
     // Fail if the item does not exist in the database.
     ConditionExpression: 'attribute_exists(pk)',
     ReturnValues: 'ALL_NEW'
@@ -698,6 +733,7 @@ module.exports = {
   IS_OFFLINE,
   
   // Functions
+  canonicalizeEmail,
   setStatus,
   runQuery,
   runScan,


### PR DESCRIPTION
Adds `canonicalizeEmail()` (lowercase + trim, strip `+tag`, strip dots for `gmail.com`/`googlemail.com`).

`checkPassExists` filters on `(emailCanonical = :canonical OR email = :raw)` so Gmail dot/`+` variants collapse to one identity. `convertPassToReserved` persists both `email` (original) and `emailCanonical`. No schema migration; the OR keeps legacy records matchable. Backfill optional.

## Test plan
- [ ] `cd samNode && npm test` (new tests in `baseLayer.canonicalizeEmail.test.js`)
- [ ] Hold `a.b.c@gmail.com` then `abc@gmail.com` same facility/date → second rejected as duplicate
- [ ] Pre-existing pass (no `emailCanonical`) still detected as duplicate via `email` fallback