### PR TITLE
feat: forward source IP to token validation; log validation errors

### DIFF
--- a/samNode/handlers/writePass/index.js
+++ b/samNode/handlers/writePass/index.js
@@ -86,7 +86,7 @@ exports.handler = async (event, context) => {
     if (newObject.commit) {
       return await handleCommitPass(newObject, permissionObject.isAdmin);
     } else {
-      let value = await handleHoldPass(newObject, permissionObject.isAdmin);
+      let value = await handleHoldPass(newObject, permissionObject.isAdmin, event);
       return value
     }
   } catch (err) {
@@ -297,7 +297,7 @@ function generateCancellationLink(registrationNumber, email, parkOrcs, bookingPS
  * @returns {Promise<Object>} - A promise that resolves to the response object.
  * @throws {CustomError} - If an error occurs during the process.
  */
-async function handleHoldPass(newObject, isAdmin) {
+async function handleHoldPass(newObject, isAdmin, event) {
   logger.debug('newObject:', newObject);
   try {
     let {
@@ -311,7 +311,8 @@ async function handleHoldPass(newObject, isAdmin) {
     } = newObject;
 
     // Validating turnstile token
-    await validateToken(token);
+    const sourceIp = event?.requestContext?.identity?.sourceIp;
+    await validateToken(token, sourceIp);
 
     logger.info('GetFacility');
     logger.debug('parkOrcs:', parkOrcs);

--- a/samNode/layers/permissionLayer/permissionLayer.js
+++ b/samNode/layers/permissionLayer/permissionLayer.js
@@ -229,26 +229,25 @@ exports.getParkAccess = async function getParkAccess(park, permissionObject) {
   }
 };
 
-exports.validateToken = async function (token) {
-  // Validate the token by calling the
-  // "/siteverify" API endpoint.
-  const body = JSON.stringify({
+exports.validateToken = async function (token, remoteip) {
+  const payload = {
     secret: CF_SECRET_KEY,
     response: token
-  });
+  };
+  if (remoteip) payload.remoteip = remoteip;
 
   const url = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
   const res = await axios({
     method: 'post',
     url: url,
-    headers: {
-      'Content-Type': 'application/json'
-    },
-    data: body
+    headers: { 'Content-Type': 'application/json' },
+    data: JSON.stringify(payload)
   });
 
   logger.debug(res.data);
-  if (res.status !== 200 || !res.data.success) {
+  if (res.status !== 200 || !res.data || !res.data.success) {
+    const codes = (res.data && res.data['error-codes']) || [];
+    logger.info(`Token validation failed: ${codes.join(',') || 'unknown'}`);
     throw new CustomError('Invalid token.', 400);
   }
 };


### PR DESCRIPTION
Two small changes in `permissionLayer.validateToken`:

- Accept an optional source IP and forward it to the upstream validator.
- Log the upstream `error-codes` on a failed validation.

`handleHoldPass` now passes `event.requestContext.identity.sourceIp` through.

## Test plan
- [ ] `cd samNode && npm test` — existing `validateToken` mocks accept the new optional arg silently
- [ ] Manual: verify a successful booking still validates token in prod after deploy
- [ ] Manual: confirm logs now include the upstream error code(s) when validation fails