### PR TITLE
feat: add optional permission layer parameter

### DIFF
--- a/samNode/layers/permissionLayer/permissionLayer.js
+++ b/samNode/layers/permissionLayer/permissionLayer.js
@@ -250,4 +250,10 @@ exports.validateToken = async function (token, remoteip) {
     logger.info(`Token validation failed: ${codes.join(',') || 'unknown'}`);
     throw new CustomError('Invalid token.', 400);
   }
+
+  const expectedHost = process.env.EXPECTED_HOSTNAME;
+  if (expectedHost && res.data.hostname && res.data.hostname !== expectedHost) {
+    logger.info(`Hostname mismatch: got ${res.data.hostname}, expected ${expectedHost}`);
+    throw new CustomError('Invalid token.', 400);
+  }
 };

--- a/samNode/template.yaml
+++ b/samNode/template.yaml
@@ -122,6 +122,9 @@ Parameters:
   PublicFrontend:
     Type: String
     Default: 'http://localhost:4300/dayuse'
+  ExpectedHostname:
+    Type: String
+    Default: ''
   S3BucketData:
     Type: String
     Default: 'parks-dup-assets-tools-SAM'
@@ -1361,6 +1364,7 @@ Resources:
           METRICS_TABLE_NAME: !Ref MetricsTableName
           LOG_LEVEL: !Ref LogLevel
           PUBLIC_FRONTEND: !Ref PublicFrontend
+          EXPECTED_HOSTNAME: !Ref ExpectedHostname
       Layers:
         - !Ref BaseLayer
         - !Ref PermissionLayer


### PR DESCRIPTION
Adds a new optional CFN parameter. Defaults to empty (no-op).