### PR TITLE
feat: optional minimum hold age parameter

### DIFF
--- a/samNode/handlers/writePass/index.js
+++ b/samNode/handlers/writePass/index.js
@@ -133,6 +133,32 @@ async function handleCommitPass(newObject, isAdmin) {
       decodedToken =  verifyHoldToken(token, SECRET);
       logger.info('Decoded Token');
 
+      const minHoldAgeMs = parseInt(process.env.MIN_HOLD_AGE_MS || '0', 10);
+      const enforceHoldAge = (process.env.ENFORCE_HOLD_AGE || 'false').toLowerCase() === 'true';
+      if (minHoldAgeMs > 0 && decodedToken.iat) {
+        const ageMs = Date.now() - decodedToken.iat * 1000;
+        if (ageMs < minHoldAgeMs) {
+          console.log(JSON.stringify({
+            _aws: {
+              Timestamp: Date.now(),
+              CloudWatchMetrics: [{
+                Namespace: 'BotHealth',
+                Dimensions: [['Enforce']],
+                Metrics: [{ Name: 'HoldTooFast', Unit: 'Count' }]
+              }]
+            },
+            HoldTooFast: 1,
+            Enforce: String(enforceHoldAge),
+            ageMs: ageMs,
+            minHoldAgeMs: minHoldAgeMs
+          }));
+          logger.info(`Hold age under threshold: ${ageMs}ms < ${minHoldAgeMs}ms, enforce=${enforceHoldAge}`);
+          if (enforceHoldAge) {
+            throw new CustomError('Invalid token.', 400);
+          }
+        }
+      }
+
       facilityName = decodedToken.facilityName;
 
       bookingPSTDateTime = DateTime.fromISO(decodedToken.date);

--- a/samNode/handlers/writePass/index.js
+++ b/samNode/handlers/writePass/index.js
@@ -137,7 +137,7 @@ async function handleCommitPass(newObject, isAdmin) {
       const enforceHoldAge = (process.env.ENFORCE_HOLD_AGE || 'false').toLowerCase() === 'true';
       if (minHoldAgeMs > 0 && decodedToken.iat) {
         const ageMs = Date.now() - decodedToken.iat * 1000;
-        if (ageMs < minHoldAgeMs) {
+        if (ageMs >= 0 && ageMs < minHoldAgeMs) {
           console.log(JSON.stringify({
             _aws: {
               Timestamp: Date.now(),
@@ -154,6 +154,7 @@ async function handleCommitPass(newObject, isAdmin) {
           }));
           logger.info(`Hold age under threshold: ${ageMs}ms < ${minHoldAgeMs}ms, enforce=${enforceHoldAge}`);
           if (enforceHoldAge) {
+            try { await deleteHoldToken(token); } catch (e) { logger.error(e); }
             throw new CustomError('Invalid token.', 400);
           }
         }

--- a/samNode/template.yaml
+++ b/samNode/template.yaml
@@ -131,6 +131,12 @@ Parameters:
   EnforceTokenAge:
     Type: String
     Default: 'false'
+  MinHoldAgeMs:
+    Type: String
+    Default: '0'
+  EnforceHoldAge:
+    Type: String
+    Default: 'false'
   S3BucketData:
     Type: String
     Default: 'parks-dup-assets-tools-SAM'
@@ -1373,6 +1379,8 @@ Resources:
           EXPECTED_HOSTNAME: !Ref ExpectedHostname
           MAX_TOKEN_AGE_MS: !Ref MaxTokenAgeMs
           ENFORCE_TOKEN_AGE: !Ref EnforceTokenAge
+          MIN_HOLD_AGE_MS: !Ref MinHoldAgeMs
+          ENFORCE_HOLD_AGE: !Ref EnforceHoldAge
       Layers:
         - !Ref BaseLayer
         - !Ref PermissionLayer


### PR DESCRIPTION
Adds optional `MinHoldAgeMs` and `EnforceHoldAge` SAM parameters to the WritePass function. Defaults to `0` and `false` — no behavior change on deploy. Mirrors the shadow-mode rollout pattern from #547/#548.