### PR TITLE
Revert "fix(passes): add shortPassDate-emailCanonical-index GSI, switch queries (#552)"

### DIFF
--- a/samNode/__tests__/setup.js
+++ b/samNode/__tests__/setup.js
@@ -72,7 +72,7 @@ async function createDB(tableName = TABLE_NAME) {
           }
         },
         {
-          IndexName: 'shortPassDate-emailCanonical-index',
+          IndexName: 'shortPassDate-index',
           KeySchema: [
             {
               AttributeName: 'shortPassDate',
@@ -92,7 +92,6 @@ async function createDB(tableName = TABLE_NAME) {
               'searchLastName',
               'facilityName',
               'email',
-              'emailCanonical',
               'date',
               'shortPassDate',
               'type',

--- a/samNode/handlers/readReservation/index.js
+++ b/samNode/handlers/readReservation/index.js
@@ -151,7 +151,7 @@ async function getOverbookedData(date, facility) {
   const shortDate = DateTime.fromISO(date).toISODate();
   let queryObj = {
     TableName: TABLE_NAME,
-    IndexName: process.env.PASS_SHORTDATE_INDEX || 'shortPassDate-emailCanonical-index',
+    IndexName: 'shortPassDate-index',
     ExpressionAttributeValues: {
       ':shortPassDate': { S: shortDate },
       ':facilityName': { S: facility },

--- a/samNode/handlers/sendReminder/index.js
+++ b/samNode/handlers/sendReminder/index.js
@@ -20,7 +20,7 @@ const LOOK_AHEAD_DAYS = 1;
 // Maximum number of emails sent in a single bulk call (default for GCN is 50000).
 const MAX_BULK_SIZE = 50000;
 // Index of short dates.
-const PASS_SHORTDATE_INDEX = process.env.PASS_SHORTDATE_INDEX || 'shortPassDate-emailCanonical-index';
+const PASS_SHORTDATE_INDEX = process.env.PASS_SHORTDATE_INDEX || 'shortPassDate-index';
 
 exports.handler = async (event, context) => {
 logger.debug('Send Reminder Emails', event);
@@ -37,7 +37,7 @@ try {
   // Determine look-ahead date
   // Done this way to account for rollovers at the end of months & years
   // We have a shortPassDate-index to query the short date, in PT, that the passes are for. 
-  // Using the shortPassDate-emailCanonical-index to query short dates is only valid because all the parks live in PT. 
+  // Using the shortPassDate-index to query short dates is only valid because all the parks live in PT. 
   // If this code is used in other contexts, timezone may have to be considered when querying passes. 
   // As a default: The cronjob will fire at 00:00 UTC
   const todayPST = DateTime.now().setZone(TIMEZONE); // today's datetime in PT
@@ -45,7 +45,7 @@ try {
   const lookAheadPST = futurePST.toISODate() // Look-ahead short date in PT
 
   // Construct query for all passes reserved for the look-ahead date (PT)
-  // Query on index 'shortPassDate-emailCanonical-index' to collect passes for all parks at once
+  // Query on index 'shortPassDate-index' to collect passes for all parks at once
   let queryObj = {
     TableName: TABLE_NAME,
     IndexName: PASS_SHORTDATE_INDEX,

--- a/samNode/handlers/sendSurvey/index.js
+++ b/samNode/handlers/sendSurvey/index.js
@@ -17,7 +17,7 @@ const LOOK_BEHIND_DAYS = 1;
 // Maximum number of emails sent in a single bulk call (default for GCN is 50000).
 const MAX_BULK_SIZE = 50000;
 // Index of short dates.
-const PASS_SHORTDATE_INDEX = process.env.PASS_SHORTDATE_INDEX || 'shortPassDate-emailCanonical-index';
+const PASS_SHORTDATE_INDEX = process.env.PASS_SHORTDATE_INDEX || 'shortPassDate-index';
 // Fallback to helpshapebc homepage if no feedback survey provided
 const FEEDBACK_SURVEY_URL = process.env.FEEDBACK_SURVEY_URL || 'https://helpshapebc.gov.bc.ca/';
 const GC_NOTIFY_IS_SENDING_SURVEYS = process.env.GC_NOTIFY_IS_SENDING_SURVEYS || 'false';
@@ -33,7 +33,7 @@ exports.handler = async (event, context) => {
   // Get all passes that are expired for yesterday's sessions
   try {
     // We have a shortPassDate-index to query the short date, in PT, that the passes are for. 
-    // Using the shortPassDate-emailCanonical-index to query short dates is only valid because all the parks live in PT. 
+    // Using the shortPassDate-index to query short dates is only valid because all the parks live in PT. 
     // If this code is used in other contexts, timezone may have to be considered when querying passes. 
     // As a default: The cronjob will fire at 20:00 UTC
     const todayPST = DateTime.now().setZone(TIMEZONE); // today's datetime in PT
@@ -41,7 +41,7 @@ exports.handler = async (event, context) => {
     const yesterdayDatePST = yesterdayPST.toISODate() // Look-ahead short date in PT
 
     // Construct query for all passes reserved for the look-ahead date (PT)
-    // Query on index 'shortPassDate-emailCanonical-index' to collect passes for all parks at once
+    // Query on index 'shortPassDate-index' to collect passes for all parks at once
     // TODO: remove hard-coded Mt. Seymour only query.
     let queryObj = {
       TableName: TABLE_NAME,

--- a/samNode/layers/baseLayer/baseLayer.js
+++ b/samNode/layers/baseLayer/baseLayer.js
@@ -402,7 +402,7 @@ async function checkPassExists(facilityName, email, type, bookingPSTShortDate) {
   const emailCanonical = canonicalizeEmail(email);
   const existingPassCheckObject = {
     TableName: process.env.TABLE_NAME,
-    IndexName: process.env.PASS_SHORTDATE_INDEX || 'shortPassDate-emailCanonical-index',
+    IndexName: 'shortPassDate-index',
     KeyConditionExpression: 'shortPassDate = :shortPassDate AND facilityName = :facilityName',
     FilterExpression: '#type = :type AND passStatus IN (:reserved, :active)',
     ExpressionAttributeNames: {

--- a/samNode/layers/reservationLayer/reservationLayer.js
+++ b/samNode/layers/reservationLayer/reservationLayer.js
@@ -373,7 +373,7 @@ async function updateReservationsObjectCapacity(pk, sk, type, newBaseCapacity, n
 async function checkForOverbookedPasses(facilityName, shortPassDate, type) {
   const passesQuery = {
     TableName: TABLE_NAME,
-    IndexName: process.env.PASS_SHORTDATE_INDEX || 'shortPassDate-emailCanonical-index',
+    IndexName: 'shortPassDate-index',
     ExpressionAttributeValues: {
       ':shortPassDate': { S: shortPassDate },
       ':facilityName': { S: facilityName },
@@ -441,7 +441,7 @@ async function reverseOverbookedPasses(passes, newResAvailability) {
 async function updatePassObjectsAsOverbooked(facilityName, shortPassDate, type, numberOfPassesOverbooked) {
   const passesQuery = {
     TableName: TABLE_NAME,
-    IndexName: process.env.PASS_SHORTDATE_INDEX || 'shortPassDate-emailCanonical-index',
+    IndexName: 'shortPassDate-index',
     ExpressionAttributeValues: {
       ':shortPassDate': { S: shortPassDate },
       ':facilityName': { S: facilityName },

--- a/samNode/template.yaml
+++ b/samNode/template.yaml
@@ -118,7 +118,7 @@ Parameters:
     Default: '0.75'
   PassShortDateIndex:
     Type: String
-    Default: 'shortPassDate-emailCanonical-index'
+    Default: 'shortPassDate-index'
   PublicFrontend:
     Type: String
     Default: 'http://localhost:4300/dayuse'
@@ -1464,32 +1464,6 @@ Resources:
               - date
               - type
         - IndexName: shortPassDate-index
-          KeySchema:
-            - AttributeName: shortPassDate
-              KeyType: HASH
-            - AttributeName: facilityName
-              KeyType: RANGE
-          Projection:
-            ProjectionType: INCLUDE
-            NonKeyAttributes:
-              - phoneNumber
-              - parkName
-              - facilityType
-              - lastName
-              - creationDate
-              - email
-              - searchLastName
-              - firstName
-              - numberOfGuests
-              - license
-              - date
-              - searchFirstName
-              - pk
-              - registrationNumber
-              - isOverbooked
-              - passStatus
-              - type
-        - IndexName: shortPassDate-emailCanonical-index
           KeySchema:
             - AttributeName: shortPassDate
               KeyType: HASH

--- a/tools/backfillEmailCanonical.js
+++ b/tools/backfillEmailCanonical.js
@@ -1,5 +1,5 @@
 // Backfill emailCanonical on existing pass records that don't have it.
-// Run AFTER deploying the new shortPassDate-emailCanonical-index GSI.
+// Run AFTER deploying the shortPassDate-index projection update that includes emailCanonical.
 // Idempotent — safe to re-run; only updates records missing the field.
 //
 // Usage:

--- a/tools/capacityReport.js
+++ b/tools/capacityReport.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const { DateTime } = require('luxon');
 
 const TABLE_NAME = process.env.TABLE_NAME || 'parksreso';
-const INDEX_NAME = process.env.PASS_SHORTDATE_INDEX || 'shortPassDate-emailCanonical-index';
+const INDEX_NAME = 'shortPassDate-index';
 const FILE_NAME = 'capacityReport';
 let options = {
   region: 'ca-central-1'


### PR DESCRIPTION
Reverts #552 so the change can land cleanly as two separate PRs:

1. Template-only — adds the new GSI alongside the existing one. Deploy, wait for ACTIVE.
2. Code-only — switches queries to the new GSI.

Combining both into a single deploy creates a race window where Lambda code references the new GSI before DDB has finished backfilling it, returning `ResourceNotFoundException`. Splitting avoids that.