### PR TITLE
fix(passes): add shortPassDate-emailCanonical-index GSI + revert in-place projection change

### DIFF
--- a/samNode/template.yaml
+++ b/samNode/template.yaml
@@ -1478,6 +1478,32 @@ Resources:
               - lastName
               - creationDate
               - email
+              - searchLastName
+              - firstName
+              - numberOfGuests
+              - license
+              - date
+              - searchFirstName
+              - pk
+              - registrationNumber
+              - isOverbooked
+              - passStatus
+              - type
+        - IndexName: shortPassDate-emailCanonical-index
+          KeySchema:
+            - AttributeName: shortPassDate
+              KeyType: HASH
+            - AttributeName: facilityName
+              KeyType: RANGE
+          Projection:
+            ProjectionType: INCLUDE
+            NonKeyAttributes:
+              - phoneNumber
+              - parkName
+              - facilityType
+              - lastName
+              - creationDate
+              - email
               - emailCanonical
               - searchLastName
               - firstName


### PR DESCRIPTION
## Summary

Two changes to `ParksDUP` template — both confined to the GSI section:

1. Revert the in-place addition of `emailCanonical` to `shortPassDate-index` projection (#551). DDB rejects projection changes on existing GSIs.
2. Add a new GSI `shortPassDate-emailCanonical-index` (same key schema, projection includes `emailCanonical`).

Template-only. **No code change. No behavioral change.** Queries continue to use the existing `shortPassDate-index`. Follow-up PR will switch queries to the new GSI after this lands and the new GSI is `ACTIVE` in each env.

## After this lands

1. Deploy → CFN issues `UpdateTable` adding the new GSI (no failure this time — only an additive change on the existing one).
2. Wait for the new GSI to become `ACTIVE` in each env.
3. Follow-up PR switches queries to use `shortPassDate-emailCanonical-index`.

Supersedes #551 (which made the in-place change DDB rejects) and #552 (which bundled GSI + code switch and would race during deploy).