### PR TITLE
fix(passes): point checkPassExists at shortPassDate-emailCanonical-index

### DIFF
--- a/samNode/__tests__/setup.js
+++ b/samNode/__tests__/setup.js
@@ -110,6 +110,45 @@ async function createDB(tableName = TABLE_NAME) {
           }
         },
         {
+          IndexName: 'shortPassDate-emailCanonical-index',
+          KeySchema: [
+            {
+              AttributeName: 'shortPassDate',
+              KeyType: 'HASH'
+            },
+            {
+              AttributeName: 'facilityName',
+              KeyType: 'RANGE'
+            }
+          ],
+          Projection: {
+            ProjectionType: 'INCLUDE',
+            NonKeyAttributes: [
+              'firstName',
+              'searchFirstName',
+              'lastName',
+              'searchLastName',
+              'facilityName',
+              'email',
+              'emailCanonical',
+              'date',
+              'shortPassDate',
+              'type',
+              'registrationNumber',
+              'numberOfGuests',
+              'passStatus',
+              'phoneNumber',
+              'facilityType',
+              'creationDate',
+              'isOverbooked'
+            ]
+          },
+          ProvisionedThroughput: {
+            ReadCapacityUnits: 1,
+            WriteCapacityUnits: 1
+          }
+        },
+        {
           IndexName: 'manualLookup-index',
           KeySchema: [
             {

--- a/samNode/layers/baseLayer/baseLayer.js
+++ b/samNode/layers/baseLayer/baseLayer.js
@@ -402,7 +402,7 @@ async function checkPassExists(facilityName, email, type, bookingPSTShortDate) {
   const emailCanonical = canonicalizeEmail(email);
   const existingPassCheckObject = {
     TableName: process.env.TABLE_NAME,
-    IndexName: 'shortPassDate-index',
+    IndexName: 'shortPassDate-emailCanonical-index',
     KeyConditionExpression: 'shortPassDate = :shortPassDate AND facilityName = :facilityName',
     FilterExpression: '#type = :type AND passStatus IN (:reserved, :active)',
     ExpressionAttributeNames: {


### PR DESCRIPTION
## Summary

Switch the dup-check (`checkPassExists` in `samNode/layers/baseLayer/baseLayer.js`) to query the new `shortPassDate-emailCanonical-index` GSI added in #554.

One-line change. No template change. No other queries touched — the existing `shortPassDate-index` continues to serve overbooking checks, reminders, surveys, and reporting.