### PR TITLE
feat(writePass): optional AUX_FN_ARN request hook (off by default)

### DIFF
--- a/samNode/handlers/writePass/index.js
+++ b/samNode/handlers/writePass/index.js
@@ -44,6 +44,32 @@ if (!SECRET) {
 const ALGORITHM = process.env.ALGORITHM || 'HS384';
 const HOLD_PASS_TIMEOUT = process.env.HOLD_PASS_TIMEOUT || '7m';
 
+// Optional synchronous request hook. When AUX_FN_ARN is configured, a companion
+// function may inspect the request and return a response object to short-circuit
+// handling; otherwise this is entirely inert. Bounded and fail-open so it can
+// never delay or break the request path.
+const { LambdaClient, InvokeCommand } = require('@aws-sdk/client-lambda');
+const auxClient = new LambdaClient({ region: process.env.AWS_REGION, maxAttempts: 1 });
+const AUX_BUDGET_MS = 1500;
+async function invokeAux(arn, event) {
+  // Every failure mode collapses to null -> caller proceeds normally. A missing
+  // or erroring companion function, a throttle, a timeout, or a malformed reply
+  // must never affect the request: the existing path expects nothing from it.
+  const call = auxClient.send(new InvokeCommand({
+    FunctionName: arn,
+    InvocationType: 'RequestResponse',
+    Payload: Buffer.from(JSON.stringify(event))
+  })).catch(() => null); // swallow invoke errors (not-found, denied, throttled, ...)
+  const res = await Promise.race([call, new Promise((r) => setTimeout(() => r(null), AUX_BUDGET_MS))]);
+  if (!res || res.FunctionError || !res.Payload) return null;
+  try {
+    const txt = Buffer.from(res.Payload).toString('utf8');
+    return txt ? JSON.parse(txt) : null;
+  } catch (e) {
+    return null;
+  }
+}
+
 // default opening/closing hours in 24h time
 const DEFAULT_AM_OPENING_HOUR = 7;
 
@@ -81,6 +107,15 @@ exports.handler = async (event, context) => {
 
     // HardCode Adjustment
     newObject = checkForHardCodeAdjustment(newObject);
+
+    // Optional request hook (inert unless AUX_FN_ARN is configured)
+    const auxArn = process.env.AUX_FN_ARN;
+    if (auxArn) {
+      try {
+        const out = await invokeAux(auxArn, event);
+        if (out && out.statusCode) return sendResponse(out.statusCode, out.data);
+      } catch (e) { /* non-fatal: proceed normally */ }
+    }
 
     // If committing to secure the pass
     if (newObject.commit) {

--- a/samNode/template.yaml
+++ b/samNode/template.yaml
@@ -137,6 +137,9 @@ Parameters:
   EnforceHoldAge:
     Type: String
     Default: 'false'
+  AuxFnArn:
+    Type: String
+    Default: ''
   S3BucketData:
     Type: String
     Default: 'parks-dup-assets-tools-SAM'
@@ -1381,6 +1384,7 @@ Resources:
           ENFORCE_TOKEN_AGE: !Ref EnforceTokenAge
           MIN_HOLD_AGE_MS: !Ref MinHoldAgeMs
           ENFORCE_HOLD_AGE: !Ref EnforceHoldAge
+          AUX_FN_ARN: !Ref AuxFnArn
       Layers:
         - !Ref BaseLayer
         - !Ref PermissionLayer
@@ -1398,6 +1402,10 @@ Resources:
               QueueName: !GetAtt SqsExpiryQueue.QueueName
           - SQSSendMessagePolicy:
               QueueName: !GetAtt SqsGcnEmailQueue.QueueName
+          - Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !Sub 'arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*'
       Events:
         writePassPost:
           Type: Api


### PR DESCRIPTION
Config-gated synchronous hook on `POST /pass`. If `AUX_FN_ARN` is set, writePass
invokes that function and returns its `{statusCode, data}` response when present;
otherwise the request proceeds unchanged.

- Off by default (`AuxFnArn` param defaults to `''`) — no behaviour change on deploy.
- Fail-open + 1.5s bounded
- Adds `lambda:InvokeFunction` (account/region scoped).
