### PR TITLE
feat(writePass): persist country on reserved pass

### DIFF
--- a/samNode/handlers/writePass/index.js
+++ b/samNode/handlers/writePass/index.js
@@ -147,6 +147,7 @@ async function handleCommitPass(newObject, isAdmin) {
     parkOrcs,
     firstName,
     lastName,
+    country,
     phoneNumber,
     email,
     token,
@@ -244,7 +245,8 @@ async function handleCommitPass(newObject, isAdmin) {
                                          firstName,
                                          lastName,
                                          email,
-                                         phoneNumber);
+                                         phoneNumber,
+                                         country);
       logger.debug(JSON.stringify(pass));
       pass.registrationNumber = decodedToken.sk
       

--- a/samNode/layers/baseLayer/baseLayer.js
+++ b/samNode/layers/baseLayer/baseLayer.js
@@ -467,7 +467,7 @@ async function checkPassExists(facilityName, email, type, bookingPSTShortDate) {
  * @returns {object} - The updated pass details.
  * @throws {CustomError} - If the operation fails.
  */
-async function convertPassToReserved(decodedToken, passStatus, firstName, lastName, email, phoneNumber) {
+async function convertPassToReserved(decodedToken, passStatus, firstName, lastName, email, phoneNumber, country) {
   const emailCanonical = canonicalizeEmail(email);
   const updateParams = {
     TableName: process.env.TABLE_NAME,
@@ -511,6 +511,10 @@ async function convertPassToReserved(decodedToken, passStatus, firstName, lastNa
   if (phoneNumber) {
     updateParams.ExpressionAttributeValues[':phoneNumber'] = { S: phoneNumber };
     updateParams.UpdateExpression += ', phoneNumber = :phoneNumber';
+  };
+  if (country) {
+    updateParams.ExpressionAttributeValues[':country'] = { S: country };
+    updateParams.UpdateExpression += ', country = :country';
   };
   const command = new UpdateItemCommand(updateParams);
   try {


### PR DESCRIPTION
### Ticket:
bcgov/parks-reso-public#568

### Description:
- Thread `country` from `writePass` -> `convertPassToReserved`; write it to the pass record on commit (conditional, mirroring `phoneNumber`).
- Pairs with parks-reso-public#569 (same ticket).