### PR TITLE
fix(deploy): pass hold and token age parameters in deploy overrides

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -68,6 +68,11 @@ jobs:
           GC_NOTIFY_SURVEY_TEMPLATE_ID: ${{ vars.GC_NOTIFY_SURVEY_TEMPLATE_ID }}
           GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID: ${{ vars.GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID }}
           HOLD_PASS_TIMEOUT: ${{ vars.HOLD_PASS_TIMEOUT }}
+          # Values come from repo secrets/vars so they are not pinned in source.
+          MIN_HOLD_AGE_MS: ${{ secrets.MIN_HOLD_AGE_MS }}
+          ENFORCE_HOLD_AGE: ${{ vars.ENFORCE_HOLD_AGE }}
+          MAX_TOKEN_AGE_MS: ${{ secrets.MAX_TOKEN_AGE_MS }}
+          ENFORCE_TOKEN_AGE: ${{ vars.ENFORCE_TOKEN_AGE }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           LOW_CAPACITY_THRESHOLD: ${{ vars.LOW_CAPACITY_THRESHOLD }}
           MODERATE_CAPACITY_THRESHOLD: ${{ vars.MODERATE_CAPACITY_THRESHOLD }}
@@ -82,7 +87,7 @@ jobs:
           ARCHIVE_TABLE_NAME: ${{vars.ARCHIVE_TABLE_NAME}}
           
         run: |
-          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "AdminFrontEnd=$ADMIN_FRONTEND" "AWSAccountList=$AWS_ACCOUNT_LIST" "CFSecretKey=$CF_SECRET_KEY" "DataRegisterApiKey=$DATA_REGISTER_API_KEY" "FeedbackSurveyUrl=$FEEDBACK_SURVEY_URL" "GCNotifyApiKey=$GC_NOTIFY_API_KEY" "GCNotifyCancelTemplateID=$GC_NOTIFY_CANCEL_TEMPLATE_ID" "GCNotifyParkingReceiptTemplateID=$GC_NOTIFY_PARKING_RECEIPT_TEMPLATE_ID" "PublicFrontend=$PUBLIC_FRONTEND" "GCNotifyReminderTemplateID=$GC_NOTIFY_REMINDER_TEMPLATE_ID" "GCNotifySMSTemplateID=$GC_NOTIFY_SMS_TEMPLATE_ID" "GCNotifySurveyTemplateID=$GC_NOTIFY_SURVEY_TEMPLATE_ID" "GCNotifyTrailReceiptTemplateID=$GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID" "HoldPassTimeout=$HOLD_PASS_TIMEOUT" "JWTSecret=$JWT_SECRET" "LogLevel=debug" "LowCapacityThreshold=$LOW_CAPACITY_THRESHOLD" "ModerateCapacityThreshold=$MODERATE_CAPACITY_THRESHOLD" "S3BucketData=$S3_BUCKET_DATA" "SSOIssuerUrl=$SSO_ISSUER_URL" "SSOJWKSUri=$SSO_JWKS_URI" "WebHookURL=$WEBHOOK_URL" "GCNotifyQueue=$GC_NOTIFY_QUEUE" "SQSExpiryQueueURL=$SQS_EXPIRY_QUEUE_URL" "GCNotifyIsSendingReminders=$GC_NOTIFY_IS_SENDING_REMINDERS" "ArchiveTableName=$ARCHIVE_TABLE_NAME"
+          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "AdminFrontEnd=$ADMIN_FRONTEND" "AWSAccountList=$AWS_ACCOUNT_LIST" "CFSecretKey=$CF_SECRET_KEY" "DataRegisterApiKey=$DATA_REGISTER_API_KEY" "FeedbackSurveyUrl=$FEEDBACK_SURVEY_URL" "GCNotifyApiKey=$GC_NOTIFY_API_KEY" "GCNotifyCancelTemplateID=$GC_NOTIFY_CANCEL_TEMPLATE_ID" "GCNotifyParkingReceiptTemplateID=$GC_NOTIFY_PARKING_RECEIPT_TEMPLATE_ID" "PublicFrontend=$PUBLIC_FRONTEND" "GCNotifyReminderTemplateID=$GC_NOTIFY_REMINDER_TEMPLATE_ID" "GCNotifySMSTemplateID=$GC_NOTIFY_SMS_TEMPLATE_ID" "GCNotifySurveyTemplateID=$GC_NOTIFY_SURVEY_TEMPLATE_ID" "GCNotifyTrailReceiptTemplateID=$GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID" "HoldPassTimeout=$HOLD_PASS_TIMEOUT" "MinHoldAgeMs=$MIN_HOLD_AGE_MS" "EnforceHoldAge=$ENFORCE_HOLD_AGE" "MaxTokenAgeMs=$MAX_TOKEN_AGE_MS" "EnforceTokenAge=$ENFORCE_TOKEN_AGE" "JWTSecret=$JWT_SECRET" "LogLevel=debug" "LowCapacityThreshold=$LOW_CAPACITY_THRESHOLD" "ModerateCapacityThreshold=$MODERATE_CAPACITY_THRESHOLD" "S3BucketData=$S3_BUCKET_DATA" "SSOIssuerUrl=$SSO_ISSUER_URL" "SSOJWKSUri=$SSO_JWKS_URI" "WebHookURL=$WEBHOOK_URL" "GCNotifyQueue=$GC_NOTIFY_QUEUE" "SQSExpiryQueueURL=$SQS_EXPIRY_QUEUE_URL" "GCNotifyIsSendingReminders=$GC_NOTIFY_IS_SENDING_REMINDERS" "ArchiveTableName=$ARCHIVE_TABLE_NAME"
 
       - shell: bash
         env:

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -87,6 +87,11 @@ jobs:
           GC_NOTIFY_SURVEY_TEMPLATE_ID: ${{ vars.GC_NOTIFY_SURVEY_TEMPLATE_ID }}
           GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID: ${{ vars.GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID }}
           HOLD_PASS_TIMEOUT: ${{ vars.HOLD_PASS_TIMEOUT }}
+          # Values come from repo secrets/vars so they are not pinned in source.
+          MIN_HOLD_AGE_MS: ${{ secrets.MIN_HOLD_AGE_MS }}
+          ENFORCE_HOLD_AGE: ${{ vars.ENFORCE_HOLD_AGE }}
+          MAX_TOKEN_AGE_MS: ${{ secrets.MAX_TOKEN_AGE_MS }}
+          ENFORCE_TOKEN_AGE: ${{ vars.ENFORCE_TOKEN_AGE }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           LOW_CAPACITY_THRESHOLD: ${{ vars.LOW_CAPACITY_THRESHOLD }}
           MODERATE_CAPACITY_THRESHOLD: ${{ vars.MODERATE_CAPACITY_THRESHOLD }}
@@ -102,7 +107,7 @@ jobs:
           WRITE_METRICS_CRON: ${{vars.WRITE_METRICS_CRON}}
           
         run: |
-          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "AdminFrontEnd=$ADMIN_FRONTEND" "AWSAccountList=$AWS_ACCOUNT_LIST" "CFSecretKey=$CF_SECRET_KEY" "DataRegisterApiKey=$DATA_REGISTER_API_KEY" "FeedbackSurveyUrl=$FEEDBACK_SURVEY_URL" "GCNotifyApiKey=$GC_NOTIFY_API_KEY" "GCNotifyCancelTemplateID=$GC_NOTIFY_CANCEL_TEMPLATE_ID" "GCNotifyParkingReceiptTemplateID=$GC_NOTIFY_PARKING_RECEIPT_TEMPLATE_ID" "PublicFrontend=$PUBLIC_FRONTEND" "GCNotifyReminderTemplateID=$GC_NOTIFY_REMINDER_TEMPLATE_ID" "GCNotifySMSTemplateID=$GC_NOTIFY_SMS_TEMPLATE_ID" "GCNotifySurveyTemplateID=$GC_NOTIFY_SURVEY_TEMPLATE_ID" "GCNotifyTrailReceiptTemplateID=$GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID" "HoldPassTimeout=$HOLD_PASS_TIMEOUT" "JWTSecret=$JWT_SECRET" "LogLevel=debug" "LowCapacityThreshold=$LOW_CAPACITY_THRESHOLD" "ModerateCapacityThreshold=$MODERATE_CAPACITY_THRESHOLD" "S3BucketData=$S3_BUCKET_DATA" "SSOIssuerUrl=$SSO_ISSUER_URL" "SSOJWKSUri=$SSO_JWKS_URI" "WebHookURL=$WEBHOOK_URL" "GCNotifyQueue=$GC_NOTIFY_QUEUE" "SQSExpiryQueueURL=$SQS_EXPIRY_QUEUE_URL" "GCNotifyIsSendingReminders=$GC_NOTIFY_IS_SENDING_REMINDERS" "ArchiveTableName=$ARCHIVE_TABLE_NAME" "WriteMetricsCron=$WRITE_METRICS_CRON"
+          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "AdminFrontEnd=$ADMIN_FRONTEND" "AWSAccountList=$AWS_ACCOUNT_LIST" "CFSecretKey=$CF_SECRET_KEY" "DataRegisterApiKey=$DATA_REGISTER_API_KEY" "FeedbackSurveyUrl=$FEEDBACK_SURVEY_URL" "GCNotifyApiKey=$GC_NOTIFY_API_KEY" "GCNotifyCancelTemplateID=$GC_NOTIFY_CANCEL_TEMPLATE_ID" "GCNotifyParkingReceiptTemplateID=$GC_NOTIFY_PARKING_RECEIPT_TEMPLATE_ID" "PublicFrontend=$PUBLIC_FRONTEND" "GCNotifyReminderTemplateID=$GC_NOTIFY_REMINDER_TEMPLATE_ID" "GCNotifySMSTemplateID=$GC_NOTIFY_SMS_TEMPLATE_ID" "GCNotifySurveyTemplateID=$GC_NOTIFY_SURVEY_TEMPLATE_ID" "GCNotifyTrailReceiptTemplateID=$GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID" "HoldPassTimeout=$HOLD_PASS_TIMEOUT" "MinHoldAgeMs=$MIN_HOLD_AGE_MS" "EnforceHoldAge=$ENFORCE_HOLD_AGE" "MaxTokenAgeMs=$MAX_TOKEN_AGE_MS" "EnforceTokenAge=$ENFORCE_TOKEN_AGE" "JWTSecret=$JWT_SECRET" "LogLevel=debug" "LowCapacityThreshold=$LOW_CAPACITY_THRESHOLD" "ModerateCapacityThreshold=$MODERATE_CAPACITY_THRESHOLD" "S3BucketData=$S3_BUCKET_DATA" "SSOIssuerUrl=$SSO_ISSUER_URL" "SSOJWKSUri=$SSO_JWKS_URI" "WebHookURL=$WEBHOOK_URL" "GCNotifyQueue=$GC_NOTIFY_QUEUE" "SQSExpiryQueueURL=$SQS_EXPIRY_QUEUE_URL" "GCNotifyIsSendingReminders=$GC_NOTIFY_IS_SENDING_REMINDERS" "ArchiveTableName=$ARCHIVE_TABLE_NAME" "WriteMetricsCron=$WRITE_METRICS_CRON"
 
       - shell: bash
         env:

--- a/.github/workflows/deploy-test.yaml
+++ b/.github/workflows/deploy-test.yaml
@@ -90,6 +90,11 @@ jobs:
           GC_NOTIFY_SURVEY_TEMPLATE_ID: ${{ vars.GC_NOTIFY_SURVEY_TEMPLATE_ID }}
           GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID: ${{ vars.GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID }}
           HOLD_PASS_TIMEOUT: ${{ vars.HOLD_PASS_TIMEOUT }}
+          # Values come from repo secrets/vars so they are not pinned in source.
+          MIN_HOLD_AGE_MS: ${{ secrets.MIN_HOLD_AGE_MS }}
+          ENFORCE_HOLD_AGE: ${{ vars.ENFORCE_HOLD_AGE }}
+          MAX_TOKEN_AGE_MS: ${{ secrets.MAX_TOKEN_AGE_MS }}
+          ENFORCE_TOKEN_AGE: ${{ vars.ENFORCE_TOKEN_AGE }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           LOW_CAPACITY_THRESHOLD: ${{ vars.LOW_CAPACITY_THRESHOLD }}
           MODERATE_CAPACITY_THRESHOLD: ${{ vars.MODERATE_CAPACITY_THRESHOLD }}
@@ -104,7 +109,7 @@ jobs:
           ARCHIVE_TABLE_NAME: ${{vars.ARCHIVE_TABLE_NAME}}
           
         run: |
-          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "AdminFrontEnd=$ADMIN_FRONTEND" "AWSAccountList=$AWS_ACCOUNT_LIST" "CFSecretKey=$CF_SECRET_KEY" "DataRegisterApiKey=$DATA_REGISTER_API_KEY" "FeedbackSurveyUrl=$FEEDBACK_SURVEY_URL" "GCNotifyApiKey=$GC_NOTIFY_API_KEY" "GCNotifyCancelTemplateID=$GC_NOTIFY_CANCEL_TEMPLATE_ID" "GCNotifyParkingReceiptTemplateID=$GC_NOTIFY_PARKING_RECEIPT_TEMPLATE_ID" "PublicFrontend=$PUBLIC_FRONTEND" "GCNotifyReminderTemplateID=$GC_NOTIFY_REMINDER_TEMPLATE_ID" "GCNotifySMSTemplateID=$GC_NOTIFY_SMS_TEMPLATE_ID" "GCNotifySurveyTemplateID=$GC_NOTIFY_SURVEY_TEMPLATE_ID" "GCNotifyTrailReceiptTemplateID=$GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID" "HoldPassTimeout=$HOLD_PASS_TIMEOUT" "JWTSecret=$JWT_SECRET" "LogLevel=debug" "LowCapacityThreshold=$LOW_CAPACITY_THRESHOLD" "ModerateCapacityThreshold=$MODERATE_CAPACITY_THRESHOLD" "S3BucketData=$S3_BUCKET_DATA" "SSOIssuerUrl=$SSO_ISSUER_URL" "SSOJWKSUri=$SSO_JWKS_URI" "WebHookURL=$WEBHOOK_URL" "GCNotifyQueue=$GC_NOTIFY_QUEUE" "SQSExpiryQueueURL=$SQS_EXPIRY_QUEUE_URL" "GCNotifyIsSendingReminders=$GC_NOTIFY_IS_SENDING_REMINDERS" "ArchiveTableName=$ARCHIVE_TABLE_NAME"
+          sam deploy --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides "AdminFrontEnd=$ADMIN_FRONTEND" "AWSAccountList=$AWS_ACCOUNT_LIST" "CFSecretKey=$CF_SECRET_KEY" "DataRegisterApiKey=$DATA_REGISTER_API_KEY" "FeedbackSurveyUrl=$FEEDBACK_SURVEY_URL" "GCNotifyApiKey=$GC_NOTIFY_API_KEY" "GCNotifyCancelTemplateID=$GC_NOTIFY_CANCEL_TEMPLATE_ID" "GCNotifyParkingReceiptTemplateID=$GC_NOTIFY_PARKING_RECEIPT_TEMPLATE_ID" "PublicFrontend=$PUBLIC_FRONTEND" "GCNotifyReminderTemplateID=$GC_NOTIFY_REMINDER_TEMPLATE_ID" "GCNotifySMSTemplateID=$GC_NOTIFY_SMS_TEMPLATE_ID" "GCNotifySurveyTemplateID=$GC_NOTIFY_SURVEY_TEMPLATE_ID" "GCNotifyTrailReceiptTemplateID=$GC_NOTIFY_TRAIL_RECEIPT_TEMPLATE_ID" "HoldPassTimeout=$HOLD_PASS_TIMEOUT" "MinHoldAgeMs=$MIN_HOLD_AGE_MS" "EnforceHoldAge=$ENFORCE_HOLD_AGE" "MaxTokenAgeMs=$MAX_TOKEN_AGE_MS" "EnforceTokenAge=$ENFORCE_TOKEN_AGE" "JWTSecret=$JWT_SECRET" "LogLevel=debug" "LowCapacityThreshold=$LOW_CAPACITY_THRESHOLD" "ModerateCapacityThreshold=$MODERATE_CAPACITY_THRESHOLD" "S3BucketData=$S3_BUCKET_DATA" "SSOIssuerUrl=$SSO_ISSUER_URL" "SSOJWKSUri=$SSO_JWKS_URI" "WebHookURL=$WEBHOOK_URL" "GCNotifyQueue=$GC_NOTIFY_QUEUE" "SQSExpiryQueueURL=$SQS_EXPIRY_QUEUE_URL" "GCNotifyIsSendingReminders=$GC_NOTIFY_IS_SENDING_REMINDERS" "ArchiveTableName=$ARCHIVE_TABLE_NAME"
 
       - shell: bash
         env:


### PR DESCRIPTION
### Problem

`MinHoldAgeMs`, `EnforceHoldAge`, `MaxTokenAgeMs` and `EnforceTokenAge` are declared in `samNode/template.yaml` with defaults of `'0'` / `'false'`, and are wired into the WritePass function's environment:

```yaml
MAX_TOKEN_AGE_MS: !Ref MaxTokenAgeMs
ENFORCE_TOKEN_AGE: !Ref EnforceTokenAge
MIN_HOLD_AGE_MS: !Ref MinHoldAgeMs
ENFORCE_HOLD_AGE: !Ref EnforceHoldAge
```

None of the four are passed in any deploy workflow's `--parameter-overrides`. CloudFormation applies the template default to any parameter that is not supplied, so **every deploy resets all four to `'0'` / `'false'`**, discarding whatever is configured on the function. A value set outside the pipeline therefore survives only until the next release.

### Change

Pass all four from repo secrets/vars in `deploy-dev`, `deploy-test` and `deploy-prod`, using the same `env:` block + shell-variable pattern (`"MinHoldAgeMs=$MIN_HOLD_AGE_MS"`) already used for `JWTSecret`. GitHub renders the `run:` script into the log *before* shell expansion, so the values are not written to workflow logs.

Numeric thresholds are held as **secrets**; the boolean toggles as **vars**.

### Configuration required for this to take effect

| Name | Kind |
| --- | --- |
| `MIN_HOLD_AGE_MS` | secret |
| `MAX_TOKEN_AGE_MS` | secret |
| `ENFORCE_HOLD_AGE` | variable |
| `ENFORCE_TOKEN_AGE` | variable |

If any are unset the deploy passes an empty string and that parameter falls back to its template default — identical to today's behaviour. The change is therefore safe to merge before they are populated, but has no effect until they are.

### Notes

Workflow-only; no template or handler changes. Behaviour is unchanged for any environment where these secrets/vars are not configured.
